### PR TITLE
new runtime vtuString simulation func

### DIFF
--- a/SPHINXsys/src/shared/io_system/in_output.cpp
+++ b/SPHINXsys/src/shared/io_system/in_output.cpp
@@ -153,6 +153,33 @@ namespace SPH
 		return _vtuData;
 	}
 	//=============================================================================================//
+	BodyStatesRecordingToVtuStringRunTime::BodyStatesRecordingToVtuStringRunTime(In_Output& in_output, SPHBodyVector bodies) 
+			: BodyStatesRecordingToVtu(in_output, bodies)
+	{
+	}	
+	//=============================================================================================//
+	void BodyStatesRecordingToVtuStringRunTime::writeWithFileName(const std::string& sequence)
+	{
+		for (SPHBody* body : bodies_)
+		{
+			if (body->checkNewlyUpdated())
+			{
+				const auto& vtuName = body->getBodyName() + "_" + sequence + ".vtu";
+				std::stringstream sstream;
+				//begin of the XML file
+				writeVtu(sstream, body);
+				std::get<0>(_vtuDataRunTime) = vtuName;
+				std::get<1>(_vtuDataRunTime) = sstream.str();
+			}
+			body->setNotNewlyUpdated();
+		}
+	}
+	//=============================================================================================//
+	const BodyStatesRecordingToVtuStringRunTime::VtuStringDataRunTime& BodyStatesRecordingToVtuStringRunTime::GetVtuDataRunTime() const
+	{
+		return _vtuDataRunTime;
+	}
+	//=============================================================================================//
 	SurfaceOnlyBodyStatesRecordingToVtu::SurfaceOnlyBodyStatesRecordingToVtu(In_Output& in_output, SPHBodyVector bodies)
 			: BodyStatesRecording(in_output, bodies),
 			surface_body_layer_vector_({})

--- a/SPHINXsys/src/shared/io_system/in_output.h
+++ b/SPHINXsys/src/shared/io_system/in_output.h
@@ -246,7 +246,7 @@ namespace SPH {
 
 		const VtuStringDataRunTime& GetVtuDataRunTime() const;
 	protected:
-		virtual void writeWithFileName(const std::string& sequence) override;
+		void writeWithFileName(const std::string& sequence) override;
 	private:
 		VtuStringDataRunTime _vtuDataRunTime;
 	};

--- a/SPHINXsys/src/shared/io_system/in_output.h
+++ b/SPHINXsys/src/shared/io_system/in_output.h
@@ -231,6 +231,27 @@ namespace SPH {
 	};
 
 	/**
+	 * @class BodyStatesRecordingToVtuStringRunTime
+	 * @brief  Writes simulation results as strings for bodies in rum time
+	 * the output is a std::pair of strings with VTK XML format that can be visualized by ParaView
+	 * the data type vtkUnstructedGrid
+	 */
+	class BodyStatesRecordingToVtuStringRunTime : public BodyStatesRecordingToVtu
+	{
+	public:
+		BodyStatesRecordingToVtuStringRunTime(In_Output& in_output, SPHBodyVector bodies);
+		virtual ~BodyStatesRecordingToVtuStringRunTime() = default;
+
+		using VtuStringDataRunTime = std::pair<std::string, std::string>;
+
+		const VtuStringDataRunTime& GetVtuDataRunTime() const;
+	protected:
+		virtual void writeWithFileName(const std::string& sequence) override;
+	private:
+		VtuStringDataRunTime _vtuDataRunTime;
+	};
+
+	/**
 	 * @class SurfaceOnlyBodyStatesRecordingToVtu
 	 * @brief  Write files for surface particles of bodies
 	 * the output file is VTK XML format can visualized by ParaView


### PR DESCRIPTION
new runtime vtuString I/O function is written to write VTUs in run time using a std::pair