### PR TITLE
Fix Saint Venant-Kirchhoff material and throw for other materials

### DIFF
--- a/src/shared/materials/elastic_solid.cpp
+++ b/src/shared/materials/elastic_solid.cpp
@@ -169,6 +169,11 @@ Matd OrthotropicSolid::StressPK2(Matd &F, size_t index_i)
     return stress_PK2;
 }
 //=================================================================================================//
+Matd OrthotropicSolid::StressCauchy(Matd &almansi_strain, Matd &F, size_t index_i)
+{
+    throw std::runtime_error("OrthotropicSolid::StressCauchy is not implemented.");
+}
+//=================================================================================================//
 Real OrthotropicSolid::VolumetricKirchhoff(Real J)
 {
     return K0_ * J * (J - 1);
@@ -187,6 +192,11 @@ Matd FeneNeoHookeanSolid::StressPK2(Matd &F, size_t index_i)
     Real J = F.determinant();
     return G0_ / (1.0 - 2.0 * strain.trace() / j1_m_) * Matd::Identity() +
            (lambda0_ * (J - 1.0) - G0_) * J * right_cauchy.inverse();
+}
+//=================================================================================================//
+Matd FeneNeoHookeanSolid::StressCauchy(Matd &almansi_strain, Matd &F, size_t index_i)
+{
+    throw std::runtime_error("FeneNeoHookeanSolid::StressCauchy is not implemented.");
 }
 //=================================================================================================//
 Real Muscle::getShearModulus(const Real (&a0)[4], const Real (&b0)[4])
@@ -224,6 +234,11 @@ Matd Muscle::StressPK2(Matd &F, size_t i)
            a0_[3] * I_fs * exp(b0_[3] * I_fs * I_fs) * f0s0_;
 }
 //=================================================================================================//
+Matd Muscle::StressCauchy(Matd &almansi_strain, Matd &F, size_t index_i)
+{
+    throw std::runtime_error("Muscle::StressCauchy is not implemented.");
+}
+//=================================================================================================//
 Real Muscle::VolumetricKirchhoff(Real J)
 {
     return K0_ * J * (J - 1);
@@ -242,6 +257,11 @@ Matd LocallyOrthotropicMuscle::StressPK2(Matd &F, size_t i)
            2.0 * a0_[1] * I_ff_1 * exp(b0_[1] * I_ff_1 * I_ff_1) * local_f0f0_[i] +
            2.0 * a0_[2] * I_ss_1 * exp(b0_[2] * I_ss_1 * I_ss_1) * local_s0s0_[i] +
            a0_[3] * I_fs * exp(b0_[3] * I_fs * I_fs) * local_f0s0_[i];
+}
+//=================================================================================================//
+Matd LocallyOrthotropicMuscle::StressCauchy(Matd &almansi_strain, Matd &F, size_t index_i)
+{
+    throw std::runtime_error("LocallyOrthotropicMuscle::StressCauchy is not implemented.");
 }
 //=================================================================================================//
 void LocallyOrthotropicMuscle::registerReloadLocalParameters(BaseParticles *base_particles)

--- a/src/shared/materials/elastic_solid.cpp
+++ b/src/shared/materials/elastic_solid.cpp
@@ -80,6 +80,16 @@ Matd SaintVenantKirchhoffSolid::StressPK2(Matd &F, size_t index_i)
     return lambda0_ * strain.trace() * Matd::Identity() + 2.0 * G0_ * strain;
 }
 //=================================================================================================//
+Matd SaintVenantKirchhoffSolid::StressCauchy(Matd &almansi_strain, Matd &F, size_t index_i)
+{
+    const auto I = SPH::Mat3d::Identity();
+    const SPH::Mat3d B = (I - 2 * almansi_strain).inverse();
+    const double J = std::sqrt(B.determinant());
+    const double trE = 0.5 * (B.trace() - 3); // tr(C) == tr(B)
+    const auto F_E_FT = 0.5 * (B * B - B);
+    return (lambda0_ * trE * B + 2.0 * G0_ * F_E_FT) / J;
+}
+//=================================================================================================//
 Matd NeoHookeanSolid::StressPK2(Matd &F, size_t index_i)
 {
     // This formulation allows negative determinant of F. Please refer Eq. (12) in
@@ -116,8 +126,7 @@ Matd NeoHookeanSolidIncompressible::StressPK2(Matd &F, size_t index_i)
 Matd NeoHookeanSolidIncompressible::
     StressCauchy(Matd &almansi_strain, Matd &F, size_t index_i)
 {
-    // TODO: implement
-    return {};
+    throw std::runtime_error("NeoHookeanSolidIncompressible::StressCauchy is not implemented.");
 }
 //=================================================================================================//
 Real NeoHookeanSolidIncompressible::VolumetricKirchhoff(Real J)

--- a/src/shared/materials/elastic_solid.h
+++ b/src/shared/materials/elastic_solid.h
@@ -28,9 +28,8 @@
  *			and anisotropic muscle, are derived from the basic elastic solid class.
  * @author	Chi Zhang and Xiangyu Hu
  */
-
-#ifndef VIRTOSIM_ELASTIC_SOLID_H_BFFCE97E_D31E_455A_96E5_D1904C02E06E
-#define VIRTOSIM_ELASTIC_SOLID_H_BFFCE97E_D31E_455A_96E5_D1904C02E06E
+#ifndef ELASTIC_SOLID_H
+#define ELASTIC_SOLID_H
 
 #include "base_material.h"
 #include <fstream>
@@ -339,4 +338,4 @@ class LocallyOrthotropicMuscle : public Muscle
     virtual std::string getRelevantStressMeasureName() override { return "Cauchy"; };
 };
 } // namespace SPH
-#endif // VIRTOSIM_ELASTIC_SOLID_H_BFFCE97E_D31E_455A_96E5_D1904C02E06E
+#endif // ELASTIC_SOLID_H

--- a/src/shared/materials/elastic_solid.h
+++ b/src/shared/materials/elastic_solid.h
@@ -28,6 +28,7 @@
  *			and anisotropic muscle, are derived from the basic elastic solid class.
  * @author	Chi Zhang and Xiangyu Hu
  */
+
 #ifndef ELASTIC_SOLID_H
 #define ELASTIC_SOLID_H
 

--- a/src/shared/materials/elastic_solid.h
+++ b/src/shared/materials/elastic_solid.h
@@ -29,8 +29,8 @@
  * @author	Chi Zhang and Xiangyu Hu
  */
 
-#ifndef ELASTIC_SOLID_H
-#define ELASTIC_SOLID_H
+#ifndef VIRTOSIM_ELASTIC_SOLID_H_BFFCE97E_D31E_455A_96E5_D1904C02E06E
+#define VIRTOSIM_ELASTIC_SOLID_H_BFFCE97E_D31E_455A_96E5_D1904C02E06E
 
 #include "base_material.h"
 #include <fstream>
@@ -220,6 +220,7 @@ class OrthotropicSolid : public LinearElasticSolid
 
     /** second Piola-Kirchhoff stress related with green-lagrangian deformation tensor */
     virtual Matd StressPK2(Matd &deformation, size_t particle_index_i) override;
+    virtual Matd StressCauchy(Matd &almansi_strain, Matd &F, size_t particle_index_i) override;
     /** Volumetric Kirchhoff stress determinate */
     virtual Real VolumetricKirchhoff(Real J) override;
 
@@ -255,6 +256,7 @@ class FeneNeoHookeanSolid : public LinearElasticSolid
     };
     virtual ~FeneNeoHookeanSolid(){};
     virtual Matd StressPK2(Matd &deformation, size_t particle_index_i) override;
+    virtual Matd StressCauchy(Matd &almansi_strain, Matd &F, size_t particle_index_i) override;
     /** Define the calculation of the stress matrix for postprocessing */
     virtual std::string getRelevantStressMeasureName() override { return "Cauchy"; };
 };
@@ -282,6 +284,7 @@ class Muscle : public NeoHookeanSolid
     virtual Matd MuscleFiberDirection(size_t particle_index_i) { return f0f0_; };
     /** compute the stress through Constitutive relation. */
     virtual Matd StressPK2(Matd &deformation, size_t particle_index_i) override;
+    virtual Matd StressCauchy(Matd &almansi_strain, Matd &F, size_t particle_index_i) override;
     /** Volumetric Kirchhoff stress form determinate */
     virtual Real VolumetricKirchhoff(Real J) override;
     /** Define the calculation of the stress matrix for postprocessing */
@@ -331,8 +334,9 @@ class LocallyOrthotropicMuscle : public Muscle
     virtual Matd MuscleFiberDirection(size_t particle_index_i) override { return local_f0f0_[particle_index_i]; };
     /** Compute the stress through Constitutive relation. */
     virtual Matd StressPK2(Matd &deformation, size_t particle_index_i) override;
+    virtual Matd StressCauchy(Matd &almansi_strain, Matd &F, size_t particle_index_i) override;
     /** Define the calculation of the stress matrix for postprocessing */
     virtual std::string getRelevantStressMeasureName() override { return "Cauchy"; };
 };
 } // namespace SPH
-#endif // ELASTIC_SOLID_H
+#endif // VIRTOSIM_ELASTIC_SOLID_H_BFFCE97E_D31E_455A_96E5_D1904C02E06E

--- a/src/shared/materials/elastic_solid.h
+++ b/src/shared/materials/elastic_solid.h
@@ -155,6 +155,7 @@ class SaintVenantKirchhoffSolid : public LinearElasticSolid
 
     /** second Piola-Kirchhoff stress related with green-lagrangian deformation tensor */
     virtual Matd StressPK2(Matd &deformation, size_t particle_index_i) override;
+    virtual Matd StressCauchy(Matd &almansi_strain, Matd &F, size_t particle_index_i) override;
 };
 
 /**


### PR DESCRIPTION
This pull request introduces the `StressCauchy` method to several classes in the `elastic_solid` module. The new method is implemented for `SaintVenantKirchhoffSolid` and added as a placeholder that throws an exception for other classes. Additionally, the method is declared in the corresponding header files.

### Implementation of `StressCauchy` method:

* [`src/shared/materials/elastic_solid.cpp`](diffhunk://#diff-92b3857d61c08c9f1a131904fc8aa47728b5d767ad8cf22baed77f5db9618b80R83-R92): Implemented `StressCauchy` method for `SaintVenantKirchhoffSolid` class.
* [`src/shared/materials/elastic_solid.cpp`](diffhunk://#diff-92b3857d61c08c9f1a131904fc8aa47728b5d767ad8cf22baed77f5db9618b80L119-R129) [[1]](diffhunk://#diff-92b3857d61c08c9f1a131904fc8aa47728b5d767ad8cf22baed77f5db9618b80L119-R129) [[2]](diffhunk://#diff-92b3857d61c08c9f1a131904fc8aa47728b5d767ad8cf22baed77f5db9618b80R172-R176) [[3]](diffhunk://#diff-92b3857d61c08c9f1a131904fc8aa47728b5d767ad8cf22baed77f5db9618b80R197-R201) [[4]](diffhunk://#diff-92b3857d61c08c9f1a131904fc8aa47728b5d767ad8cf22baed77f5db9618b80R237-R241) [[5]](diffhunk://#diff-92b3857d61c08c9f1a131904fc8aa47728b5d767ad8cf22baed77f5db9618b80R262-R266) [[6]](diffhunk://#diff-0edd72c9cc77ee6ae5ca5684b22c883673322dead433055695cf3732b8a7605cR158) and [`src/shared/materials/elastic_solid.h`](diffhunk://#diff-0edd72c9cc77ee6ae5ca5684b22c883673322dead433055695cf3732b8a7605cR158) [[7]](diffhunk://#diff-0edd72c9cc77ee6ae5ca5684b22c883673322dead433055695cf3732b8a7605cR223) [[8]](diffhunk://#diff-0edd72c9cc77ee6ae5ca5684b22c883673322dead433055695cf3732b8a7605cR259) [[9]](diffhunk://#diff-0edd72c9cc77ee6ae5ca5684b22c883673322dead433055695cf3732b8a7605cR287) [[10]](diffhunk://#diff-0edd72c9cc77ee6ae5ca5684b22c883673322dead433055695cf3732b8a7605cR337): Added `StressCauchy` method throwing `std::runtime_error` for `NeoHookeanSolidIncompressible`, `OrthotropicSolid`, `FeneNeoHookeanSolid`, `Muscle`, and `LocallyOrthotropicMuscle` classes. 
