### PR TITLE
Enforce numerically plane stress condition for shell formulation

### DIFF
--- a/src/shared/particle_dynamics/solid_dynamics/thin_structure_dynamics.cpp
+++ b/src/shared/particle_dynamics/solid_dynamics/thin_structure_dynamics.cpp
@@ -139,12 +139,33 @@ void ShellStressRelaxationFirstHalf::initialization(size_t index_i, Real dt)
                                             (Matd::Identity() - inverse_F_gaussian_point.transpose() * inverse_F_gaussian_point) *
                                             transformation_matrix_[index_i] * current_transformation_matrix.transpose();
 
-        /** correct Almansi strain tensor according to plane stress problem. */
-        current_local_almansi_strain = getCorrectedAlmansiStrain(current_local_almansi_strain, nu_);
+        current_local_almansi_strain(2, 2) = 0;
+        Matd cauchy_stress = elastic_solid_.StressCauchy(current_local_almansi_strain, F_gaussian_point, index_i);
+        { /// Enforce plane stress condition adapting algorithm from Sec. 5.4.1 from http://dx.doi.org/10.18419/opus-14215
+          /// Differential geometry and the geometrically non-linear Reissner-Mindlin shell model
+          /// @WARN Algorithm is not guaranteed to converge, see discussion in Sec. 5.4.1
+          ///       even more so considering we do not reuse analytical derivatives.
 
-        /** correct out-plane numerical damping. */
-        Matd cauchy_stress = elastic_solid_.StressCauchy(current_local_almansi_strain, F_gaussian_point, index_i) + current_transformation_matrix * transformation_matrix_[index_i].transpose() * F_gaussian_point *
-                                                                                                                        elastic_solid_.NumericalDampingRightCauchy(F_gaussian_point, dF_gaussian_point_dt, numerical_damping_scaling_[index_i], index_i) * F_gaussian_point.transpose() * transformation_matrix_[index_i] * current_transformation_matrix.transpose() / F_gaussian_point.determinant();
+            double E = E0_; // Take the default Young's modulus of the material as the initial derivative.
+            int it = 0;
+            int max_it = 20;
+            for (double s_next = 1.0; abs(s_next) > 1e-9 && it < max_it; ++it) // @WARN Hardcoded tolerance and iteration limit.
+            {
+                double e_prev = current_local_almansi_strain(2, 2);
+                double s_prev = cauchy_stress(2, 2);
+                double e_next = e_prev - s_prev / E;
+                current_local_almansi_strain(2, 2) = e_next;
+                cauchy_stress = elastic_solid_.StressCauchy(current_local_almansi_strain, F_gaussian_point, index_i);
+                s_next = cauchy_stress(2, 2);
+                E = (s_next - s_prev) / (e_next - e_prev);
+            }
+            if (cauchy_stress.allFinite() == false || it == max_it)
+                throw std::runtime_error("Algorithm enforcing plane stress condition for shell failed.");
+        }
+        /// Impact of including numerical damping in the algorithm above unclear
+        /// Left here in absence of discriminating factors
+        Matd damping = current_transformation_matrix * transformation_matrix_[index_i].transpose() * F_gaussian_point * elastic_solid_.NumericalDampingRightCauchy(F_gaussian_point, dF_gaussian_point_dt, numerical_damping_scaling_[index_i], index_i) * F_gaussian_point.transpose() * transformation_matrix_[index_i] * current_transformation_matrix.transpose() / F_gaussian_point.determinant();
+        cauchy_stress += damping;
 
         /** Impose modeling assumptions. */
         cauchy_stress.col(Dimensions - 1) *= shear_correction_factor_;

--- a/src/shared/particle_dynamics/solid_dynamics/thin_structure_dynamics.cpp
+++ b/src/shared/particle_dynamics/solid_dynamics/thin_structure_dynamics.cpp
@@ -152,7 +152,7 @@ void ShellStressRelaxationFirstHalf::initialization(size_t index_i, Real dt)
             constexpr auto infinity = std::numeric_limits<Real>::infinity();
             auto tolerance_sqr = [](const Matd &stress)
             {
-                return std::max(Eps, Eps * stress.colwise().squaredNorm().minCoeff());
+                return std::max(Eps, Eps * stress.block<2, 2>(0, 0).colwise().squaredNorm().minCoeff());
             };
             for (double s_next = infinity;
                  s_next * s_next > tolerance_sqr(cauchy_stress) && it < max_iterations;


### PR DESCRIPTION
This pull request includes significant updates to the `initialization` method in the `ShellStressRelaxationFirstHalf` class to improve the handling of plane stress conditions. The changes involve replacing the previous approach with a new iterative algorithm.

### Handling Plane Stress Conditions:

Replaced the `getCorrectedAlmansiStrain` method with a new iterative algorithm to enforce plane stress conditions. This includes a hardcoded tolerance and iteration limit, and throws an exception if the algorithm fails to converge.

The algorithm follows the standard method for finite strain described in Sec. 5.4.1 of the PhD thesis _"Differential geometry and the geometrically non-linear Reissner-Mindlin shell model"_ [[doi]](http://dx.doi.org/10.18419/opus-14215), with 2 main adaptation.

1. The algorithm enforces $`\boldsymbol\sigma(\bf{e})=0`$ instead of $`\bf{S}(\bf{E})=0`$ due to existing implementation choices of SPHinXsys
2. The algorithm uses the [secant method](https://en.wikipedia.org/wiki/Secant_method), therefore relying only on 1st order (i.e. strain and stress) information to avoid implementing the calculation of the stiffness tangent. The tangent update is calculated as 

```math
E^{i+1}=\frac{\sigma^{i+1}-\sigma^{i}}{\bf{e}^{i+1}-\bf{e}^{i}}
```

where $E$ is the instantaneous Young's modulus.

The default algorithm, albeit a definitive improvement over the "linear isotropic material" approximation, is not guaranteed to converge. Indeed, the update procedure Eq. (5.127) propagates violation of the positive definiteness, and thus, may fail for material model calculating the stretches from the Left/Right Cauchy-Green tensor (wherein $`\lambda_i^2\leq0`$).

Those additional modification obviously can render the algorithm more brittle, checks are performed to detect non-finite values slipping in the stress.

In past experiments with customer cases, the simulation was failing for a set of parameters previously used, however the behavior of the structure was visibly extreme (buckling, kinks) and not desired, pushing for modifying simulation parameters rather than accepting it as an intrinsic failure of the algorithm.

An improvement to the algorithm is described in the thesis mentioned above in sec. 5.4.2, but its implementation is not straightforward due to SPHinXsys peculiarities and left for a future issue.