### PR TITLE
Increase hourglass control scalar parameter

### DIFF
--- a/src/shared/particle_dynamics/solid_dynamics/thin_structure_dynamics.cpp
+++ b/src/shared/particle_dynamics/solid_dynamics/thin_structure_dynamics.cpp
@@ -101,7 +101,7 @@ ShellStressRelaxationFirstHalf::
         gaussian_weight_ = three_gaussian_weights_;
     }
     /** Define the factor of hourglass control algorithm. */
-    hourglass_control_factor_ = 0.002;
+    hourglass_control_factor_ = 0.01;
 }
 //=================================================================================================//
 void ShellStressRelaxationFirstHalf::initialization(size_t index_i, Real dt)

--- a/src/shared/particle_dynamics/solid_dynamics/thin_structure_dynamics.h
+++ b/src/shared/particle_dynamics/solid_dynamics/thin_structure_dynamics.h
@@ -236,6 +236,9 @@ class ShellStressRelaxationFirstHalf : public BaseShellRelaxation
 
     void update(size_t index_i, Real dt = 0.0);
 
+    inline double hourglass_control_factor() const { return hourglass_control_factor_; };
+    inline void hourglass_control_factor(double value) { hourglass_control_factor_ = value; };
+
   protected:
     ElasticSolid &elastic_solid_;
     StdLargeVec<Matd> &global_stress_, &global_moment_, &mid_surface_cauchy_stress_, &numerical_damping_scaling_;

--- a/src/shared/particle_dynamics/solid_dynamics/thin_structure_dynamics.h
+++ b/src/shared/particle_dynamics/solid_dynamics/thin_structure_dynamics.h
@@ -236,8 +236,8 @@ class ShellStressRelaxationFirstHalf : public BaseShellRelaxation
 
     void update(size_t index_i, Real dt = 0.0);
 
-    inline double hourglass_control_factor() const { return hourglass_control_factor_; };
-    inline void hourglass_control_factor(double value) { hourglass_control_factor_ = value; };
+    inline Real hourglass_control_factor() const { return hourglass_control_factor_; };
+    inline void hourglass_control_factor(Real value) { hourglass_control_factor_ = value; };
 
   protected:
     ElasticSolid &elastic_solid_;


### PR DESCRIPTION
The change increases the factor value to improve the hourglass control algorithm.

* [`src/shared/particle_dynamics/solid_dynamics/thin_structure_dynamics.cpp`](diffhunk://#diff-7b78d5f0cb0599195c1ed11bf841b7e6f635c9c43c155fb33496b64290669d4cL104-R104): Increased `hourglass_control_factor_` from 0.002 to 0.01.

The impact of the parameter is once again unclear, however it has proven itself too small when using corrected material models, where the stiffness rises much higher than previously