### PR TITLE
Fix bounding box of a transformed shape

### DIFF
--- a/src/shared/geometries/transform_shape.h
+++ b/src/shared/geometries/transform_shape.h
@@ -75,8 +75,24 @@ class TransformShape : public BaseShapeType
     virtual BoundingBox findBounds() override
     {
         BoundingBox original_bound = BaseShapeType::findBounds();
-        return BoundingBox(transform_.shiftFrameStationToBase(original_bound.first_),
-                           transform_.shiftFrameStationToBase(original_bound.second_));
+        Vecd bb_min = Vecd::Constant(Infinity);
+        Vecd bb_max = Vecd::Constant(-Infinity);
+        for (auto x : {original_bound.first_.x(), original_bound.second_.x()})
+            for (auto y : {original_bound.first_.y(), original_bound.second_.y()})
+            {
+                if constexpr (Dimensions == 3)
+                    for (auto z : {original_bound.first_.z(), original_bound.second_.z()})
+                    {
+                        bb_min = bb_min.cwiseMin(transform_.shiftFrameStationToBase(Vecd(x, y, z)));
+                        bb_max = bb_max.cwiseMax(transform_.shiftFrameStationToBase(Vecd(x, y, z)));
+                    }
+                else
+                {
+                    bb_min = bb_min.cwiseMin(transform_.shiftFrameStationToBase(Vecd(x, y)));
+                    bb_max = bb_max.cwiseMax(transform_.shiftFrameStationToBase(Vecd(x, y)));
+                }
+            }
+        return BoundingBox(bb_min, bb_max);
     };
 };
 } // namespace SPH


### PR DESCRIPTION
Bounding box is updated by finding the min/max of all the transformed corner of the original bounding box, instead of the rotated bounds which is incorrect.

Note that **this does not return the minimal bounding box**, the tight fit AABB of the transformed shape is highly dependent on the underlying shape.