### PR TITLE
Fix typo hourglass control for shell

### DIFF
--- a/src/shared/particle_dynamics/solid_dynamics/thin_structure_dynamics.h
+++ b/src/shared/particle_dynamics/solid_dynamics/thin_structure_dynamics.h
@@ -206,7 +206,7 @@ class ShellStressRelaxationFirstHalf : public BaseShellRelaxation
                 Vecd pos_jump = getLinearVariableJump(e_ij, r_ij, pos_[index_i],
                                                       transformation_matrix_[index_i].transpose() * F_[index_i] * transformation_matrix_[index_i],
                                                       pos_[index_j],
-                                                      transformation_matrix_[index_i].transpose() * F_[index_j] * transformation_matrix_[index_i]);
+                                                      transformation_matrix_[index_j].transpose() * F_[index_j] * transformation_matrix_[index_j]);
                 Real limiter_pos = SMIN(2.0 * pos_jump.norm() / r_ij, 1.0);
                 acceleration += hourglass_control_factor_ * weight * G0_ * pos_jump * Dimensions *
                                 inner_neighborhood.dW_ijV_j_[n] * limiter_pos;
@@ -217,7 +217,7 @@ class ShellStressRelaxationFirstHalf : public BaseShellRelaxation
                                                            transformation_matrix_[index_i].transpose() * F_bending_[index_i] * transformation_matrix_[index_i],
                                                            pseudo_n_variation_j,
                                                            transformation_matrix_[index_j].transpose() * F_bending_[index_j] * transformation_matrix_[index_j]);
-                Real limiter_pseudo_n = SMIN(2.0 * pseudo_n_jump.norm() / ((pseudo_n_variation_i- pseudo_n_variation_j).norm() + Eps), 1.0);
+                Real limiter_pseudo_n = SMIN(2.0 * pseudo_n_jump.norm() / ((pseudo_n_variation_i - pseudo_n_variation_j).norm() + Eps), 1.0);
                 pseudo_normal_acceleration += hourglass_control_factor_ * weight * G0_ * pseudo_n_jump * Dimensions *
                                               inner_neighborhood.dW_ijV_j_[n] * pow(thickness_[index_i], 2) * limiter_pseudo_n;
             }


### PR DESCRIPTION
Corrected the transformation matrix for the `pos_jump` calculation in the `ShellStressRelaxationFirstHalf` class to use the appropriate index for the second particle. (`src/shared/particle_dynamics/solid_dynamics/thin_structure_dynamics.h`, [src/shared/particle_dynamics/solid_dynamics/thin_structure_dynamics.hL209-R209](diffhunk://#diff-951fce3e839bd81932c43d3cb76d2b2a2870e25ca6bac3cfad321bd2e32aa742L209-R209))