### PR TITLE
Change the definition of contact stiffness

### DIFF
--- a/modules/structural_simulation/structural_simulation_class.cpp
+++ b/modules/structural_simulation/structural_simulation_class.cpp
@@ -356,8 +356,8 @@ void StructuralSimulation::initializeContactBetweenTwoBodies(int first, int seco
     contact_list_.emplace_back(makeShared<SurfaceContactRelation>(*second_body, RealBodyVector({first_body})));
 
     int last = contact_list_.size() - 1;
-    contact_density_list_.push_back(makeShared<InteractionDynamics<solid_dynamics::ContactDensitySummation>>(*contact_list_[last - 1]));
-    contact_density_list_.push_back(makeShared<InteractionDynamics<solid_dynamics::ContactDensitySummation>>(*contact_list_[last]));
+    contact_density_list_.push_back(makeShared<InteractionDynamics<solid_dynamics::RepulsionFactorSummation>>(*contact_list_[last - 1]));
+    contact_density_list_.push_back(makeShared<InteractionDynamics<solid_dynamics::RepulsionFactorSummation>>(*contact_list_[last]));
 
     contact_force_list_.push_back(makeShared<InteractionDynamics<solid_dynamics::ContactForce>>(*contact_list_[last - 1]));
     contact_force_list_.push_back(makeShared<InteractionDynamics<solid_dynamics::ContactForce>>(*contact_list_[last]));
@@ -381,7 +381,7 @@ void StructuralSimulation::initializeAllContacts()
 
         contact_list_.emplace_back(makeShared<SurfaceContactRelation>(*contact_body, target_list));
         int last = contact_list_.size() - 1;
-        contact_density_list_.emplace_back(makeShared<InteractionDynamics<solid_dynamics::ContactDensitySummation>>(*contact_list_[last]));
+        contact_density_list_.emplace_back(makeShared<InteractionDynamics<solid_dynamics::RepulsionFactorSummation>>(*contact_list_[last]));
         contact_force_list_.emplace_back(makeShared<InteractionDynamics<solid_dynamics::ContactForce>>(*contact_list_[last]));
     }
     // continue appending the lists with the time dependent contacts
@@ -666,7 +666,7 @@ void StructuralSimulation::executeSpringNormalOnSurfaceParticles()
     }
 }
 
-void StructuralSimulation::executeContactDensitySummation()
+void StructuralSimulation::executeRepulsionFactorSummation()
 {
     // number of contacts that are not time dependent: contact pairs * 2
     size_t number_of_general_contacts = contacting_body_pairs_list_.size();
@@ -853,7 +853,7 @@ void StructuralSimulation::runSimulationStep(Real &dt, Real &integration_time)
     executeSpringNormalOnSurfaceParticles();
 
     /** CONTACT */
-    executeContactDensitySummation();
+    executeRepulsionFactorSummation();
     executeContactForce();
 
     /** STRESS RELAXATION, DAMPING, POSITIONAL CONSTRAINTS */

--- a/modules/structural_simulation/structural_simulation_class.h
+++ b/modules/structural_simulation/structural_simulation_class.h
@@ -73,7 +73,7 @@ class BodyPartFromMesh : public BodyRegionByParticle
 {
   public:
     BodyPartFromMesh(SPHBody &body, SharedPtr<TriangleMeshShape> triangle_mesh_shape_ptr);
-    ~BodyPartFromMesh(){};
+    ~BodyPartFromMesh() {};
 };
 
 class SolidBodyFromMesh : public SolidBody
@@ -81,7 +81,7 @@ class SolidBodyFromMesh : public SolidBody
   public:
     SolidBodyFromMesh(SPHSystem &system, SharedPtr<TriangleMeshShape> triangle_mesh_shape, Real resolution,
                       SharedPtr<SaintVenantKirchhoffSolid> material_model, StdLargeVec<Vec3d> &pos_0, StdLargeVec<Real> &volume);
-    ~SolidBodyFromMesh(){};
+    ~SolidBodyFromMesh() {};
 };
 
 class SolidBodyForSimulation
@@ -101,7 +101,7 @@ class SolidBodyForSimulation
     SolidBodyForSimulation(
         SPHSystem &system, SharedPtr<TriangleMeshShape> triangle_mesh_shape, Real resolution,
         Real physical_viscosity, SharedPtr<SaintVenantKirchhoffSolid> material_model, StdLargeVec<Vec3d> &pos_0, StdLargeVec<Real> &volume);
-    ~SolidBodyForSimulation(){};
+    ~SolidBodyForSimulation() {};
 
     SolidBodyFromMesh *getSolidBodyFromMesh() { return &solid_body_from_mesh_; };
     ElasticSolidParticles *getElasticSolidParticles() { return DynamicCast<ElasticSolidParticles>(this, &solid_body_from_mesh_.getBaseParticles()); };
@@ -206,7 +206,7 @@ class StructuralSimulation
     StdVec<SharedPtr<SimpleDynamics<solid_dynamics::UpdateElasticNormalDirection>>> particle_normal_update_;
 
     StdVec<SharedPtr<SurfaceContactRelation>> contact_list_;
-    StdVec<SharedPtr<InteractionDynamics<solid_dynamics::ContactDensitySummation>>> contact_density_list_;
+    StdVec<SharedPtr<InteractionDynamics<solid_dynamics::RepulsionFactorSummation>>> contact_density_list_;
     StdVec<SharedPtr<InteractionDynamics<solid_dynamics::ContactForce>>> contact_force_list_;
 
     // for initializeATimeStep
@@ -289,7 +289,7 @@ class StructuralSimulation
     void executeSurfacePressure();
     void executeSpringDamperConstraintParticleWise();
     void executeSpringNormalOnSurfaceParticles();
-    void executeContactDensitySummation();
+    void executeRepulsionFactorSummation();
     void executeContactForce();
     void executeStressRelaxationFirstHalf(Real dt);
     void executeConstrainSolidBody();

--- a/src/shared/materials/base_material.h
+++ b/src/shared/materials/base_material.h
@@ -59,14 +59,14 @@ class BaseMaterial
     std::string MaterialType() { return material_type_name_; }
     Real ReferenceDensity() { return rho0_; };
     /**interface called in base particles constructor */
-    virtual void registerReloadLocalParameters(BaseParticles *base_particles){};
+    virtual void registerReloadLocalParameters(BaseParticles *base_particles) {};
     /**
      * This will be called after particles generation
      * and is important because particles are not defined yet when material is constructed.
      * For a composite material, i.e. there is a material pointer with another material,
      * one need assign the base particle to that material too.
      */
-    virtual void initializeLocalParameters(BaseParticles *base_particles){};
+    virtual void initializeLocalParameters(BaseParticles *base_particles) {};
     virtual BaseMaterial *ThisObjectPtr() { return this; };
 
   protected:
@@ -129,7 +129,7 @@ class Solid : public BaseMaterial
     Real contact_stiffness_; /**< contact-force stiffness related to bulk modulus*/
     Real contact_friction_;  /**< friction property mimic fluid viscosity*/
 
-    void setContactStiffness(Real c0) { contact_stiffness_ = c0 * c0; };
+    void setContactStiffness(Real c0) { contact_stiffness_ = rho0_ * c0 * c0; };
 };
 } // namespace SPH
 #endif // BASE_MATERIAL_H

--- a/src/shared/particle_dynamics/solid_dynamics/contact_dynamics.cpp
+++ b/src/shared/particle_dynamics/solid_dynamics/contact_dynamics.cpp
@@ -94,10 +94,12 @@ ContactForce::ContactForce(SurfaceContactRelation &solid_body_contact_relation)
       Vol_(particles_->Vol_), mass_(particles_->mass_),
       acc_prior_(particles_->acc_prior_)
 {
-    // Inspired by the pinball contact algorithm which defines F2 = Gi * Gj / (Gi + Gj) * sqrt(Ri * Rj/(Ri+Rj)) * p^{3/2},
-    // where Gi, Gj are the shear modulus, Ri, Rj are the radius of the particles, and p is the penetration related to particle distance and normal direction,
+    // The Hertzian theory of non-adhesive elastic contact between two balls gives the analytical solution F = 4/3* E* sqrt(R)* delta^(3/2),
+    // where the composite Young's modulus of elasticity 1/E* = (1-v1^2)/E1 + (1-v2^2)/E2, the effective radius 1/R = 1/R1 + 1/R2,
+    // Ref: https://en.wikipedia.org/wiki/Contact_mechanics#Hertzian_theory_of_non-adhesive_elastic_contact
+    // The pinball contact algorithm also defines the contact force with a similar formula F2 = Gi * Gj / (Gi + Gj) * sqrt(Ri * Rj/(Ri+Rj)) * p^{3/2}
     // Ref: https://doi.org/10.1016/0045-7825(93)90064-5, The splitting pinball method for contact-impact problems
-    // We define the contact stiffness as the harmonic average K = 2 * Ki * Kj / (Ki + Kj), where K1, K2 are the contact stiffness of the two bodies.
+    // Inspired by the composite modulus in these formulas, we define the contact stiffness as the harmonic average K = 2 * Ki * Kj / (Ki + Kj), where K1, K2 are the contact stiffness of the two bodies.
     // In comparison of geometric average, the harmonic average is dominant by the softer material.
     // Empirically, the harmonic average is sufficient to prevent penetration, and matches the time-step size of the softer material.
     // This allows us to use a different time-step size for the two materials

--- a/src/shared/particle_dynamics/solid_dynamics/contact_dynamics.cpp
+++ b/src/shared/particle_dynamics/solid_dynamics/contact_dynamics.cpp
@@ -94,6 +94,13 @@ ContactForce::ContactForce(SurfaceContactRelation &solid_body_contact_relation)
       Vol_(particles_->Vol_), mass_(particles_->mass_),
       acc_prior_(particles_->acc_prior_)
 {
+    // Inspired by the pinball contact algorithm which defines F2 = Gi * Gj / (Gi + Gj) * sqrt(Ri * Rj/(Ri+Rj)) * p^{3/2},
+    // where Gi, Gj are the shear modulus, Ri, Rj are the radius of the particles, and p is the penetration related to particle distance and normal direction,
+    // Ref: https://doi.org/10.1016/0045-7825(93)90064-5, The splitting pinball method for contact-impact problems
+    // We define the contact stiffness as the harmonic average K = 2 * Ki * Kj / (Ki + Kj), where K1, K2 are the contact stiffness of the two bodies.
+    // In comparison of geometric average, the harmonic average is dominant by the softer material.
+    // Empirically, the harmonic average is sufficient to prevent penetration, and matches the time-step size of the softer material.
+    // This allows us to use a different time-step size for the two materials
     Real K_1 = solid_.ContactStiffness();
     for (size_t k = 0; k != contact_particles_.size(); ++k)
     {

--- a/src/shared/particle_dynamics/solid_dynamics/contact_dynamics.cpp
+++ b/src/shared/particle_dynamics/solid_dynamics/contact_dynamics.cpp
@@ -10,9 +10,9 @@ namespace SPH
 namespace solid_dynamics
 {
 //=================================================================================================//
-SelfContactDensitySummation::
-    SelfContactDensitySummation(SelfSurfaceContactRelation &self_contact_relation)
-    : ContactDensityAccessor(self_contact_relation.base_particles_, "SelfContactDensity"),
+SelfRepulsionFactorSummation::
+    SelfRepulsionFactorSummation(SelfSurfaceContactRelation &self_contact_relation)
+    : RepulsionFactorAccessor(self_contact_relation.base_particles_, "SelfRepulsionFactor"),
       LocalDynamics(self_contact_relation.getSPHBody()),
       SolidDataInner(self_contact_relation),
       Vol_(particles_->Vol_)
@@ -21,9 +21,9 @@ SelfContactDensitySummation::
     offset_W_ij_ = self_contact_relation.getSPHBody().sph_adaptation_->getKernel()->W(dp_1, ZeroVecd);
 }
 //=================================================================================================//
-ContactDensitySummation::
-    ContactDensitySummation(SurfaceContactRelation &solid_body_contact_relation)
-    : ContactDensityAccessor(solid_body_contact_relation.base_particles_, "ContactDensity"),
+RepulsionFactorSummation::
+    RepulsionFactorSummation(SurfaceContactRelation &solid_body_contact_relation)
+    : RepulsionFactorAccessor(solid_body_contact_relation.base_particles_, "RepulsionFactor"),
       LocalDynamics(solid_body_contact_relation.getSPHBody()),
       ContactDynamicsData(solid_body_contact_relation), Vol_(particles_->Vol_),
       offset_W_ij_(StdVec<Real>(contact_configuration_.size(), 0.0))
@@ -47,8 +47,8 @@ ContactDensitySummation::
     }
 }
 //=================================================================================================//
-ShellContactDensity::ShellContactDensity(SurfaceContactRelation &solid_body_contact_relation)
-    : ContactDensityAccessor(solid_body_contact_relation.base_particles_, "ContactDensity"),
+ShellRepulsionFactor::ShellRepulsionFactor(SurfaceContactRelation &solid_body_contact_relation)
+    : RepulsionFactorAccessor(solid_body_contact_relation.base_particles_, "RepulsionFactor"),
       LocalDynamics(solid_body_contact_relation.getSPHBody()),
       ContactDynamicsData(solid_body_contact_relation), solid_(particles_->solid_),
       kernel_(solid_body_contact_relation.getSPHBody().sph_adaptation_->getKernel()),
@@ -81,7 +81,7 @@ SelfContactForce::
     : LocalDynamics(self_contact_relation.getSPHBody()),
       SolidDataInner(self_contact_relation),
       solid_(particles_->solid_), mass_(particles_->mass_),
-      self_contact_density_(*particles_->getVariableByName<Real>("SelfContactDensity")),
+      self_repulsion_factor_(*particles_->getVariableByName<Real>("SelfRepulsionFactor")),
       Vol_(particles_->Vol_), acc_prior_(particles_->acc_prior_),
       vel_(particles_->vel_),
       contact_impedance_(solid_.ReferenceDensity() * sqrt(solid_.ContactStiffness())) {}
@@ -90,7 +90,7 @@ ContactForce::ContactForce(SurfaceContactRelation &solid_body_contact_relation)
     : LocalDynamics(solid_body_contact_relation.getSPHBody()),
       ContactDynamicsData(solid_body_contact_relation),
       solid_(particles_->solid_),
-      contact_density_(*particles_->getVariableByName<Real>("ContactDensity")),
+      repulsion_factor_(*particles_->getVariableByName<Real>("RepulsionFactor")),
       Vol_(particles_->Vol_), mass_(particles_->mass_),
       acc_prior_(particles_->acc_prior_)
 {
@@ -107,7 +107,7 @@ ContactForce::ContactForce(SurfaceContactRelation &solid_body_contact_relation)
     for (size_t k = 0; k != contact_particles_.size(); ++k)
     {
         contact_solids_.push_back(&contact_particles_[k]->solid_);
-        contact_contact_density_.push_back(contact_particles_[k]->getVariableByName<Real>("ContactDensity"));
+        contact_repulsion_factor_.push_back(contact_particles_[k]->getVariableByName<Real>("RepulsionFactor"));
         Real K_2 = contact_solids_[k]->ContactStiffness();
         contact_stiffness_.emplace_back(2 * K_1 * K_2 / (K_1 + K_2));
     }
@@ -116,7 +116,7 @@ ContactForce::ContactForce(SurfaceContactRelation &solid_body_contact_relation)
 ContactForceFromWall::ContactForceFromWall(SurfaceContactRelation &solid_body_contact_relation)
     : LocalDynamics(solid_body_contact_relation.getSPHBody()),
       ContactWithWallData(solid_body_contact_relation), solid_(particles_->solid_),
-      contact_density_(*particles_->getVariableByName<Real>("ContactDensity")),
+      repulsion_factor_(*particles_->getVariableByName<Real>("RepulsionFactor")),
       Vol_(particles_->Vol_), mass_(particles_->mass_),
       acc_prior_(particles_->acc_prior_) {}
 //=================================================================================================//
@@ -129,7 +129,7 @@ ContactForceToWall::ContactForceToWall(SurfaceContactRelation &solid_body_contac
     for (size_t k = 0; k != contact_particles_.size(); ++k)
     {
         contact_solids_.push_back(&contact_particles_[k]->solid_);
-        contact_contact_density_.push_back(contact_particles_[k]->getVariableByName<Real>("ContactDensity"));
+        contact_repulsion_factor_.push_back(contact_particles_[k]->getVariableByName<Real>("RepulsionFactor"));
     }
 }
 //=================================================================================================//

--- a/src/shared/particle_dynamics/solid_dynamics/contact_dynamics.h
+++ b/src/shared/particle_dynamics/solid_dynamics/contact_dynamics.h
@@ -43,7 +43,7 @@ class ContactDensityAccessor
 {
   protected:
     ContactDensityAccessor(BaseParticles &particles, const std::string &variable_name)
-        : contact_density_(*particles.registerSharedVariable<Real>(variable_name)){};
+        : contact_density_(*particles.registerSharedVariable<Real>(variable_name)) {};
     ~ContactDensityAccessor() = default;
     StdLargeVec<Real> &contact_density_;
 };
@@ -56,7 +56,7 @@ class SelfContactDensitySummation : public ContactDensityAccessor, public LocalD
 {
   public:
     explicit SelfContactDensitySummation(SelfSurfaceContactRelation &self_contact_relation);
-    virtual ~SelfContactDensitySummation(){};
+    virtual ~SelfContactDensitySummation() {};
 
     inline void interaction(size_t index_i, Real dt = 0.0)
     {
@@ -83,7 +83,7 @@ class ContactDensitySummation : public ContactDensityAccessor, public LocalDynam
 {
   public:
     explicit ContactDensitySummation(SurfaceContactRelation &solid_body_contact_relation);
-    virtual ~ContactDensitySummation(){};
+    virtual ~ContactDensitySummation() {};
 
     inline void interaction(size_t index_i, Real dt = 0.0)
     {
@@ -118,7 +118,7 @@ class ShellContactDensity : public ContactDensityAccessor, public LocalDynamics,
 {
   public:
     explicit ShellContactDensity(SurfaceContactRelation &solid_body_contact_relation);
-    virtual ~ShellContactDensity(){};
+    virtual ~ShellContactDensity() {};
 
     inline void interaction(size_t index_i, Real dt = 0.0)
     {
@@ -167,7 +167,7 @@ class SelfContactForce : public LocalDynamics, public SolidDataInner
 {
   public:
     explicit SelfContactForce(SelfSurfaceContactRelation &self_contact_relation);
-    virtual ~SelfContactForce(){};
+    virtual ~SelfContactForce() {};
 
     inline void interaction(size_t index_i, Real dt = 0.0)
     {
@@ -205,7 +205,7 @@ class ContactForce : public LocalDynamics, public ContactDynamicsData
 {
   public:
     explicit ContactForce(SurfaceContactRelation &solid_body_contact_relation);
-    virtual ~ContactForce(){};
+    virtual ~ContactForce() {};
 
     inline void interaction(size_t index_i, Real dt = 0.0)
     {
@@ -213,13 +213,16 @@ class ContactForce : public LocalDynamics, public ContactDynamicsData
         Real sigma_i = contact_density_[index_i];
         /** Contact interaction. */
         Vecd force = Vecd::Zero();
+        // contact force from particle j: f_ij = 2 * K_ij * sigma_ij * Vi * Vj * dW_ij * e_ij
         for (size_t k = 0; k < contact_configuration_.size(); ++k)
         {
             StdLargeVec<Real> &contact_density_k = *(contact_contact_density_[k]);
 
             Neighborhood &contact_neighborhood = (*contact_configuration_[k])[index_i];
 
-            Vecd force_k = Vecd::Zero();
+            // Calculate the factor 2 * sigma_ij * Vi * Vj * dW_ij * e_ij
+            // sigma_ij = 0.5 * (sigma_i + sigma_j)
+            Vecd factor_k = Vecd::Zero();
             for (size_t n = 0; n != contact_neighborhood.current_size_; ++n)
             {
                 size_t index_j = contact_neighborhood.j_[n];
@@ -227,9 +230,9 @@ class ContactForce : public LocalDynamics, public ContactDynamicsData
 
                 Real sigma_star = 0.5 * (sigma_i + contact_density_k[index_j]);
                 // force due to pressure
-                force_k -= 2.0 * sigma_star * e_ij * Vol_i * contact_neighborhood.dW_ijV_j_[n];
+                factor_k -= 2.0 * sigma_star * e_ij * Vol_i * contact_neighborhood.dW_ijV_j_[n];
             }
-            force += contact_stiffness_[k] * force_k;
+            force += contact_stiffness_[k] * factor_k;
         }
         acc_prior_[index_i] += force / mass_[index_i];
     };
@@ -253,7 +256,7 @@ class ContactForceFromWall : public LocalDynamics, public ContactWithWallData
 {
   public:
     explicit ContactForceFromWall(SurfaceContactRelation &solid_body_contact_relation);
-    virtual ~ContactForceFromWall(){};
+    virtual ~ContactForceFromWall() {};
 
     inline void interaction(size_t index_i, Real dt = 0.0)
     {
@@ -289,7 +292,7 @@ class ContactForceToWall : public LocalDynamics, public ContactDynamicsData
 {
   public:
     explicit ContactForceToWall(SurfaceContactRelation &solid_body_contact_relation);
-    virtual ~ContactForceToWall(){};
+    virtual ~ContactForceToWall() {};
 
     inline void interaction(size_t index_i, Real dt = 0.0)
     {
@@ -333,7 +336,7 @@ class PairwiseFrictionFromWall : public LocalDynamics, public ContactWithWallDat
 {
   public:
     PairwiseFrictionFromWall(BaseContactRelation &contact_relation, Real eta);
-    virtual ~PairwiseFrictionFromWall(){};
+    virtual ~PairwiseFrictionFromWall() {};
 
     inline void interaction(size_t index_i, Real dt = 0.0)
     {
@@ -395,7 +398,7 @@ class DynamicContactForceWithWall : public LocalDynamics, public ContactDynamics
 {
   public:
     explicit DynamicContactForceWithWall(SurfaceContactRelation &solid_body_contact_relation, Real penalty_strength = 1.0);
-    virtual ~DynamicContactForceWithWall(){};
+    virtual ~DynamicContactForceWithWall() {};
 
     inline void interaction(size_t index_i, Real dt = 0.0)
     {

--- a/tests/2d_examples/test_2d_ball_shell_collision/ball_shell_collision.cpp
+++ b/tests/2d_examples/test_2d_ball_shell_collision/ball_shell_collision.cpp
@@ -175,7 +175,7 @@ int main(int ac, char *av[])
     Dynamics1Level<solid_dynamics::Integration1stHalfPK2> ball_stress_relaxation_first_half(ball_inner);
     Dynamics1Level<solid_dynamics::Integration2ndHalf> ball_stress_relaxation_second_half(ball_inner);
     /** Algorithms for solid-solid contact. */
-    InteractionDynamics<solid_dynamics::ShellContactDensity> ball_update_contact_density(ball_contact);
+    InteractionDynamics<solid_dynamics::ShellRepulsionFactor> ball_update_contact_density(ball_contact);
     InteractionDynamics<solid_dynamics::ContactForceFromWall> ball_compute_solid_contact_forces(ball_contact);
     // DampingWithRandomChoice<InteractionSplit<solid_dynamics::PairwiseFrictionFromWall>>
     // 	ball_friction(0.1, ball_contact, physical_viscosity);

--- a/tests/2d_examples/test_2d_collision/collision.cpp
+++ b/tests/2d_examples/test_2d_collision/collision.cpp
@@ -187,9 +187,9 @@ int main(int ac, char *av[])
     Dynamics1Level<solid_dynamics::Integration1stHalfPK2> damping_ball_stress_relaxation_first_half(damping_ball_inner);
     Dynamics1Level<solid_dynamics::Integration2ndHalf> damping_ball_stress_relaxation_second_half(damping_ball_inner);
     /** Algorithms for solid-solid contact. */
-    InteractionDynamics<solid_dynamics::ContactDensitySummation> free_ball_update_contact_density(free_ball_contact);
+    InteractionDynamics<solid_dynamics::RepulsionFactorSummation> free_ball_update_contact_density(free_ball_contact);
     InteractionDynamics<solid_dynamics::ContactForceFromWall> free_ball_compute_solid_contact_forces(free_ball_contact);
-    InteractionDynamics<solid_dynamics::ContactDensitySummation> damping_ball_update_contact_density(damping_ball_contact);
+    InteractionDynamics<solid_dynamics::RepulsionFactorSummation> damping_ball_update_contact_density(damping_ball_contact);
     InteractionDynamics<solid_dynamics::ContactForceFromWall> damping_ball_compute_solid_contact_forces(damping_ball_contact);
     /** Damping for one ball */
     DampingWithRandomChoice<InteractionSplit<DampingPairwiseInner<Vec2d>>>

--- a/tests/2d_examples/test_2d_self_contact/self_contact.cpp
+++ b/tests/2d_examples/test_2d_self_contact/self_contact.cpp
@@ -86,7 +86,7 @@ class BeamInitialCondition
 {
   public:
     explicit BeamInitialCondition(SPHBody &sph_body)
-        : solid_dynamics::ElasticDynamicsInitialCondition(sph_body){};
+        : solid_dynamics::ElasticDynamicsInitialCondition(sph_body) {};
 
     void update(size_t index_i, Real dt)
     {
@@ -141,7 +141,7 @@ int main(int ac, char *av[])
     ReduceDynamics<solid_dynamics::AcousticTimeStepSize> computing_time_step_size(beam_body);
     Dynamics1Level<solid_dynamics::DecomposedIntegration1stHalf> stress_relaxation_first_half(beam_body_inner);
     Dynamics1Level<solid_dynamics::Integration2ndHalf> stress_relaxation_second_half(beam_body_inner);
-    InteractionDynamics<solid_dynamics::SelfContactDensitySummation> beam_self_contact_density(beam_self_contact);
+    InteractionDynamics<solid_dynamics::SelfRepulsionFactorSummation> beam_self_contact_density(beam_self_contact);
     InteractionDynamics<solid_dynamics::SelfContactForce> beam_self_contact_forces(beam_self_contact);
     BodyRegionByParticle beam_base(beam_body, makeShared<MultiPolygonShape>(createBeamConstrainShape()));
     SimpleDynamics<solid_dynamics::FixBodyPartConstraint> constraint_beam_base(beam_base);
@@ -149,7 +149,7 @@ int main(int ac, char *av[])
     //	outputs
     //-----------------------------------------------------------------------------
     IOEnvironment io_environment(system);
-    beam_body.addBodyStateForRecording<Real>("SelfContactDensity");
+    beam_body.addBodyStateForRecording<Real>("SelfRepulsionFactor");
     BodyStatesRecordingToVtp write_beam_states(io_environment, system.real_bodies_);
     RegressionTestDynamicTimeWarping<ObservedQuantityRecording<Vecd>>
         write_beam_tip_displacement("Position", io_environment, beam_observer_contact);

--- a/tests/2d_examples/test_2d_shell_beam_collision/src/shell_beam_collision.cpp
+++ b/tests/2d_examples/test_2d_shell_beam_collision/src/shell_beam_collision.cpp
@@ -188,7 +188,7 @@ int main(int ac, char *av[])
     Dynamics1Level<solid_dynamics::Integration1stHalfPK2> beam_stress_relaxation_first_half(beam_inner);
     Dynamics1Level<solid_dynamics::Integration2ndHalf> beam_stress_relaxation_second_half(beam_inner);
     /** Algorithms for shell-solid contact. */
-    InteractionDynamics<solid_dynamics::ContactDensitySummation> beam_shell_update_contact_density(beam_contact);
+    InteractionDynamics<solid_dynamics::RepulsionFactorSummation> beam_shell_update_contact_density(beam_contact);
     InteractionDynamics<solid_dynamics::ContactForceFromWall> beam_compute_solid_contact_forces(beam_contact);
     InteractionDynamics<solid_dynamics::ContactForceToWall> shell_compute_solid_contact_forces(shell_contact);
     BodyRegionByParticle holder(beam, makeShared<MultiPolygonShape>(createBeamConstrainShape()));

--- a/tests/2d_examples/test_2d_sliding/sliding.cpp
+++ b/tests/2d_examples/test_2d_sliding/sliding.cpp
@@ -108,7 +108,7 @@ int main(int ac, char *av[])
     Dynamics1Level<solid_dynamics::Integration1stHalfPK2> free_cube_stress_relaxation_first_half(free_cube_inner);
     Dynamics1Level<solid_dynamics::Integration2ndHalf> free_cube_stress_relaxation_second_half(free_cube_inner);
     /** Algorithms for solid-solid contact. */
-    InteractionDynamics<solid_dynamics::ContactDensitySummation> free_cube_update_contact_density(free_cube_contact);
+    InteractionDynamics<solid_dynamics::RepulsionFactorSummation> free_cube_update_contact_density(free_cube_contact);
     InteractionDynamics<solid_dynamics::ContactForceFromWall> free_cube_compute_solid_contact_forces(free_cube_contact);
     /** Damping*/
     DampingWithRandomChoice<InteractionSplit<DampingPairwiseInner<Vec2d>>>

--- a/tests/3d_examples/test_3d_elasticSolid_shell_collision/3d_elasticSolid_shell_collision.cpp
+++ b/tests/3d_examples/test_3d_elasticSolid_shell_collision/3d_elasticSolid_shell_collision.cpp
@@ -35,7 +35,7 @@ Real physical_viscosity = 1.0e6;
 class CylinderParticleGenerator : public SurfaceParticleGenerator
 {
   public:
-    explicit CylinderParticleGenerator(SPHBody &sph_body) : SurfaceParticleGenerator(sph_body){};
+    explicit CylinderParticleGenerator(SPHBody &sph_body) : SurfaceParticleGenerator(sph_body) {};
     virtual void initializeGeometricVariables() override
     {
         // the cylinder and boundary
@@ -153,7 +153,7 @@ int main(int ac, char *av[])
     Dynamics1Level<solid_dynamics::DecomposedIntegration1stHalf> ball_stress_relaxation_first_half(ball_inner);
     Dynamics1Level<solid_dynamics::Integration2ndHalf> ball_stress_relaxation_second_half(ball_inner);
     /** Algorithms for solid-solid contact. */
-    InteractionDynamics<solid_dynamics::ShellContactDensity> ball_update_contact_density(ball_contact);
+    InteractionDynamics<solid_dynamics::ShellRepulsionFactor> ball_update_contact_density(ball_contact);
     InteractionDynamics<solid_dynamics::ContactForceFromWall> ball_compute_solid_contact_forces(ball_contact);
     DampingWithRandomChoice<InteractionSplit<solid_dynamics::PairwiseFrictionFromWall>>
         ball_friction(0.1, ball_contact, physical_viscosity);

--- a/tests/3d_examples/test_3d_muscle_soft_body_contact/src/muscle_soft_body_contact.cpp
+++ b/tests/3d_examples/test_3d_muscle_soft_body_contact/src/muscle_soft_body_contact.cpp
@@ -85,8 +85,8 @@ int main()
     Dynamics1Level<solid_dynamics::Integration2ndHalf> stress_relaxation_second_half_2(moving_plate_inner);
     // stress_relaxation_first_half_2.post_processes_(spring_constraint);
     /** Algorithms for solid-solid contact. */
-    InteractionDynamics<solid_dynamics::ContactDensitySummation> myocardium_update_contact_density(myocardium_plate_contact);
-    InteractionDynamics<solid_dynamics::ContactDensitySummation> plate_update_contact_density(plate_myocardium_contact);
+    InteractionDynamics<solid_dynamics::RepulsionFactorSummation> myocardium_update_contact_density(myocardium_plate_contact);
+    InteractionDynamics<solid_dynamics::RepulsionFactorSummation> plate_update_contact_density(plate_myocardium_contact);
     InteractionDynamics<solid_dynamics::ContactForce> myocardium_compute_solid_contact_forces(myocardium_plate_contact);
     InteractionDynamics<solid_dynamics::ContactForce> plate_compute_solid_contact_forces(plate_myocardium_contact);
 

--- a/tests/3d_examples/test_3d_muscle_solid_contact/src/muscle_solid_contact.cpp
+++ b/tests/3d_examples/test_3d_muscle_solid_contact/src/muscle_solid_contact.cpp
@@ -83,8 +83,8 @@ int main()
     Dynamics1Level<solid_dynamics::Integration1stHalfPK2> stress_relaxation_first_half(myocardium_body_inner);
     Dynamics1Level<solid_dynamics::Integration2ndHalf> stress_relaxation_second_half(myocardium_body_inner);
     /** Algorithms for solid-solid contact. */
-    InteractionDynamics<solid_dynamics::ContactDensitySummation> myocardium_update_contact_density(myocardium_plate_contact);
-    InteractionDynamics<solid_dynamics::ContactDensitySummation> plate_update_contact_density(plate_myocardium_contact);
+    InteractionDynamics<solid_dynamics::RepulsionFactorSummation> myocardium_update_contact_density(myocardium_plate_contact);
+    InteractionDynamics<solid_dynamics::RepulsionFactorSummation> plate_update_contact_density(plate_myocardium_contact);
     InteractionDynamics<solid_dynamics::ContactForce> myocardium_compute_solid_contact_forces(myocardium_plate_contact);
     InteractionDynamics<solid_dynamics::ContactForce> plate_compute_solid_contact_forces(plate_myocardium_contact);
     /** Constrain the holder. */

--- a/tests/3d_examples/test_3d_self_contact/3d_self_contact.cpp
+++ b/tests/3d_examples/test_3d_self_contact/3d_self_contact.cpp
@@ -143,9 +143,9 @@ int main(int ac, char *av[])
     Dynamics1Level<solid_dynamics::Integration1stHalfPK2> stress_relaxation_first_half(coil_inner);
     Dynamics1Level<solid_dynamics::Integration2ndHalf> stress_relaxation_second_half(coil_inner);
     // Algorithms for solid-solid contacts.
-    InteractionDynamics<solid_dynamics::ContactDensitySummation> coil_update_contact_density(coil_contact);
+    InteractionDynamics<solid_dynamics::RepulsionFactorSummation> coil_update_contact_density(coil_contact);
     InteractionDynamics<solid_dynamics::ContactForceFromWall> coil_compute_solid_contact_forces(coil_contact);
-    InteractionDynamics<solid_dynamics::SelfContactDensitySummation> coil_self_contact_density(coil_self_contact);
+    InteractionDynamics<solid_dynamics::SelfRepulsionFactorSummation> coil_self_contact_density(coil_self_contact);
     InteractionDynamics<solid_dynamics::SelfContactForce> coil_self_contact_forces(coil_self_contact);
     // Damping the velocity field for quasi-static solution
     DampingWithRandomChoice<InteractionSplit<DampingPairwiseInner<Vec3d>>>


### PR DESCRIPTION
See [#265](https://github.com/virtonomy-dev/virtosim/pull/265).

**Modification in the contact stiffness**
1. Compute contact density by `W_ij * Vol_[index_j]` instead of `W_ij * mass_[index_j]`
2. Redefine the contact stiffness as `c * c * rho`
3. Use the harmonic average contact stiffness `contact_stiffness_ave = 2 * contact_stiffness_i * contact_stiffness_j / (contact_stiffness_i + contact_stiffness_j)` as the contact stiffness between two bodies
4. "ContactDensity" is renamed as "RepulsionFactor"