### PR TITLE
Fix NeoHookean StressCauchy

### DIFF
--- a/src/shared/materials/elastic_solid.cpp
+++ b/src/shared/materials/elastic_solid.cpp
@@ -101,8 +101,8 @@ Matd NeoHookeanSolid::StressPK2(Matd &F, size_t index_i)
 //=================================================================================================//
 Matd NeoHookeanSolid::StressCauchy(Matd &almansi_strain, Matd &F, size_t index_i)
 {
-    Real J = F.determinant();
     Matd B = (-2.0 * almansi_strain + Matd::Identity()).inverse();
+    Real J = sqrt(B.determinant());
     Matd cauchy_stress = 0.5 * K0_ * (J - 1.0 / J) * Matd::Identity() +
                          G0_ * pow(J, -2.0 * OneOverDimensions - 1.0) *
                              (B - OneOverDimensions * B.trace() * Matd::Identity());


### PR DESCRIPTION
In NeoHookeanSolid::StressCauchy, the Jacobian J is computed from the uncorrected deformation gradient F_ instead of the corrected Almansi strain. This PR fixes this problem.

Related to [#523](https://github.com/virtonomy-dev/virtosim/pull/523)