### PR TITLE
Add fluid linear correction

### DIFF
--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex_correction.h
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex_correction.h
@@ -49,12 +49,29 @@ class BaseIntegration1stHalfCorrectWithWall : public InteractionWithWall<BaseInt
     template <typename... Args>
     BaseIntegration1stHalfCorrectWithWall(Args &&...args)
         : InteractionWithWall<BaseIntegration1stHalfCorrectType>(std::forward<Args>(args)...){};
-    virtual ~BaseIntegration1stHalfCorrectWithWall(){};
+    virtual ~BaseIntegration1stHalfCorrectWithWall() {};
     void interaction(size_t index_i, Real dt = 0.0);
 };
 
 using Integration1stHalfCorrectWithWall = BaseIntegration1stHalfCorrectWithWall<Integration1stHalfCorrect>;
 using Integration1stHalfRiemannCorrectWithWall = BaseIntegration1stHalfCorrectWithWall<Integration1stHalfRiemannCorrect>;
+
+/**
+ * @class BaseIntegration1stHalfCorrectWithWall
+ * @brief  template class pressure relaxation scheme together with wall boundary
+ */
+template <class BaseIntegration2ndHalfCorrectType>
+class BaseIntegration2ndHalfCorrectWithWall : public InteractionWithWall<BaseIntegration2ndHalfCorrectType>
+{
+  public:
+    template <typename... Args>
+    BaseIntegration2ndHalfCorrectWithWall(Args &&...args)
+        : InteractionWithWall<BaseIntegration2ndHalfCorrectType>(std::forward<Args>(args)...){};
+    void interaction(size_t index_i, Real dt = 0.0);
+};
+
+using Integration2ndHalfCorrectWithWall = BaseIntegration2ndHalfCorrectWithWall<Integration2ndHalfCorrect>;
+using Integration2ndHalfRiemannCorrectWithWall = BaseIntegration2ndHalfCorrectWithWall<Integration2ndHalfRiemannCorrect>;
 } // namespace fluid_dynamics
 } // namespace SPH
 #endif // FLUID_DYNAMICS_COMPLEX_CORRECTION_H

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex_correction.h
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex_correction.h
@@ -55,23 +55,6 @@ class BaseIntegration1stHalfCorrectWithWall : public InteractionWithWall<BaseInt
 
 using Integration1stHalfCorrectWithWall = BaseIntegration1stHalfCorrectWithWall<Integration1stHalfCorrect>;
 using Integration1stHalfRiemannCorrectWithWall = BaseIntegration1stHalfCorrectWithWall<Integration1stHalfRiemannCorrect>;
-
-/**
- * @class BaseIntegration1stHalfCorrectWithWall
- * @brief  template class pressure relaxation scheme together with wall boundary
- */
-template <class BaseIntegration2ndHalfCorrectType>
-class BaseIntegration2ndHalfCorrectWithWall : public InteractionWithWall<BaseIntegration2ndHalfCorrectType>
-{
-  public:
-    template <typename... Args>
-    BaseIntegration2ndHalfCorrectWithWall(Args &&...args)
-        : InteractionWithWall<BaseIntegration2ndHalfCorrectType>(std::forward<Args>(args)...){};
-    void interaction(size_t index_i, Real dt = 0.0);
-};
-
-using Integration2ndHalfCorrectWithWall = BaseIntegration2ndHalfCorrectWithWall<Integration2ndHalfCorrect>;
-using Integration2ndHalfRiemannCorrectWithWall = BaseIntegration2ndHalfCorrectWithWall<Integration2ndHalfRiemannCorrect>;
 } // namespace fluid_dynamics
 } // namespace SPH
 #endif // FLUID_DYNAMICS_COMPLEX_CORRECTION_H

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex_correction.hpp
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex_correction.hpp
@@ -37,33 +37,5 @@ void BaseIntegration1stHalfCorrectWithWall<BaseIntegration1stHalfCorrectType>::i
     this->drho_dt_[index_i] += rho_dissipation * this->rho_[index_i];
 }
 //=================================================================================================//
-template <class BaseIntegration2ndHalfCorrectType>
-void BaseIntegration2ndHalfCorrectWithWall<BaseIntegration2ndHalfCorrectType>::interaction(size_t index_i, Real dt)
-{
-    BaseIntegration2ndHalfCorrectType::interaction(index_i, dt);
-
-    Real density_change_rate = 0.0;
-    Vecd grad_p_dissipation = Vecd::Zero();
-    for (size_t k = 0; k < FluidWallData::contact_configuration_.size(); ++k)
-    {
-        StdLargeVec<Vecd> &vel_ave_k = *(this->wall_vel_ave_[k]);
-        StdLargeVec<Vecd> &n_k = *(this->wall_n_[k]);
-        Neighborhood &wall_neighborhood = (*FluidWallData::contact_configuration_[k])[index_i];
-        for (size_t n = 0; n != wall_neighborhood.current_size_; ++n)
-        {
-            size_t index_j = wall_neighborhood.j_[n];
-            Vecd e_ij_corrected = this->B_[index_i] * wall_neighborhood.e_ij_[n];
-            Real dW_ijV_j = wall_neighborhood.dW_ijV_j_[n];
-
-            Vecd vel_in_wall = 2.0 * vel_ave_k[index_j] - this->vel_[index_i];
-            density_change_rate += (this->vel_[index_i] - vel_in_wall).dot(e_ij_corrected) * dW_ijV_j;
-            Real u_jump = 2.0 * (this->vel_[index_i] - vel_ave_k[index_j]).dot(n_k[index_j]);
-            grad_p_dissipation += this->riemann_solver_.DissipativePJump(u_jump) * dW_ijV_j * n_k[index_j];
-        }
-    }
-    this->drho_dt_[index_i] += density_change_rate * this->rho_[index_i];
-    this->acc_[index_i] += grad_p_dissipation / this->rho_[index_i];
-}
-//=================================================================================================//
 } // namespace fluid_dynamics
 } // namespace SPH

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex_correction.hpp
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex_correction.hpp
@@ -14,7 +14,7 @@ void BaseIntegration1stHalfCorrectWithWall<BaseIntegration1stHalfCorrectType>::i
 
     Vecd acc_prior_i = this->acc_prior_[index_i];
 
-    Vecd acceleration = Vecd::Zero();
+    Vecd grad_p_i = Vecd::Zero();
     Real rho_dissipation(0);
     for (size_t k = 0; k < FluidWallData::contact_configuration_.size(); ++k)
     {
@@ -29,11 +29,11 @@ void BaseIntegration1stHalfCorrectWithWall<BaseIntegration1stHalfCorrectType>::i
 
             Real face_wall_external_acceleration = (acc_prior_i - acc_ave_k[index_j]).dot(-e_ij);
             Real p_in_wall = this->p_[index_i] + this->rho_[index_i] * r_ij * SMAX(Real(0), face_wall_external_acceleration);
-            acceleration -= (this->p_[index_i] + p_in_wall) * this->B_[index_i] * e_ij * dW_ijV_j;
+            grad_p_i -= (this->p_[index_i] + p_in_wall) * this->B_[index_i] * e_ij * dW_ijV_j;
             rho_dissipation += this->riemann_solver_.DissipativeUJump(this->p_[index_i] - p_in_wall) * dW_ijV_j;
         }
     }
-    this->acc_[index_i] += acceleration / this->rho_[index_i];
+    this->acc_[index_i] += grad_p_i / this->rho_[index_i];
     this->drho_dt_[index_i] += rho_dissipation * this->rho_[index_i];
 }
 //=================================================================================================//
@@ -43,7 +43,7 @@ void BaseIntegration2ndHalfCorrectWithWall<BaseIntegration2ndHalfCorrectType>::i
     BaseIntegration2ndHalfCorrectType::interaction(index_i, dt);
 
     Real density_change_rate = 0.0;
-    Vecd p_dissipation = Vecd::Zero();
+    Vecd grad_p_dissipation = Vecd::Zero();
     for (size_t k = 0; k < FluidWallData::contact_configuration_.size(); ++k)
     {
         StdLargeVec<Vecd> &vel_ave_k = *(this->wall_vel_ave_[k]);
@@ -58,11 +58,11 @@ void BaseIntegration2ndHalfCorrectWithWall<BaseIntegration2ndHalfCorrectType>::i
             Vecd vel_in_wall = 2.0 * vel_ave_k[index_j] - this->vel_[index_i];
             density_change_rate += (this->vel_[index_i] - vel_in_wall).dot(e_ij_corrected) * dW_ijV_j;
             Real u_jump = 2.0 * (this->vel_[index_i] - vel_ave_k[index_j]).dot(n_k[index_j]);
-            p_dissipation += this->riemann_solver_.DissipativePJump(u_jump) * dW_ijV_j * n_k[index_j];
+            grad_p_dissipation += this->riemann_solver_.DissipativePJump(u_jump) * dW_ijV_j * n_k[index_j];
         }
     }
     this->drho_dt_[index_i] += density_change_rate * this->rho_[index_i];
-    this->acc_[index_i] += p_dissipation / this->rho_[index_i];
+    this->acc_[index_i] += grad_p_dissipation / this->rho_[index_i];
 }
 //=================================================================================================//
 } // namespace fluid_dynamics

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex_correction.hpp
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex_correction.hpp
@@ -37,5 +37,33 @@ void BaseIntegration1stHalfCorrectWithWall<BaseIntegration1stHalfCorrectType>::i
     this->drho_dt_[index_i] += rho_dissipation * this->rho_[index_i];
 }
 //=================================================================================================//
+template <class BaseIntegration2ndHalfCorrectType>
+void BaseIntegration2ndHalfCorrectWithWall<BaseIntegration2ndHalfCorrectType>::interaction(size_t index_i, Real dt)
+{
+    BaseIntegration2ndHalfCorrectType::interaction(index_i, dt);
+
+    Real density_change_rate = 0.0;
+    Vecd p_dissipation = Vecd::Zero();
+    for (size_t k = 0; k < FluidWallData::contact_configuration_.size(); ++k)
+    {
+        StdLargeVec<Vecd> &vel_ave_k = *(this->wall_vel_ave_[k]);
+        StdLargeVec<Vecd> &n_k = *(this->wall_n_[k]);
+        Neighborhood &wall_neighborhood = (*FluidWallData::contact_configuration_[k])[index_i];
+        for (size_t n = 0; n != wall_neighborhood.current_size_; ++n)
+        {
+            size_t index_j = wall_neighborhood.j_[n];
+            Vecd e_ij_corrected = this->B_[index_i] * wall_neighborhood.e_ij_[n];
+            Real dW_ijV_j = wall_neighborhood.dW_ijV_j_[n];
+
+            Vecd vel_in_wall = 2.0 * vel_ave_k[index_j] - this->vel_[index_i];
+            density_change_rate += (this->vel_[index_i] - vel_in_wall).dot(e_ij_corrected) * dW_ijV_j;
+            Real u_jump = 2.0 * (this->vel_[index_i] - vel_ave_k[index_j]).dot(n_k[index_j]);
+            p_dissipation += this->riemann_solver_.DissipativePJump(u_jump) * dW_ijV_j * n_k[index_j];
+        }
+    }
+    this->drho_dt_[index_i] += density_change_rate * this->rho_[index_i];
+    this->acc_[index_i] += p_dissipation / this->rho_[index_i];
+}
+//=================================================================================================//
 } // namespace fluid_dynamics
 } // namespace SPH

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner_correction.h
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner_correction.h
@@ -48,11 +48,9 @@ class BaseIntegration1stHalfCorrect : public BaseIntegration1stHalf<RiemannSolve
     virtual ~BaseIntegration1stHalfCorrect() {};
 
     using BaseIntegration1stHalf<RiemannSolverType>::BaseIntegration1stHalf;
-    void initialization(size_t index_i, Real dt);
     void interaction(size_t index_i, Real dt);
 
   protected:
-    StdLargeVec<Matd> p_B_;
     StdLargeVec<Matd> &B_;
 };
 using Integration1stHalfCorrect = BaseIntegration1stHalfCorrect<NoRiemannSolver>;

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner_correction.h
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner_correction.h
@@ -45,7 +45,7 @@ class BaseIntegration1stHalfCorrect : public BaseIntegration1stHalf<RiemannSolve
 {
   public:
     explicit BaseIntegration1stHalfCorrect(BaseInnerRelation &inner_relation);
-    virtual ~BaseIntegration1stHalfCorrect(){};
+    virtual ~BaseIntegration1stHalfCorrect() {};
 
     using BaseIntegration1stHalf<RiemannSolverType>::BaseIntegration1stHalf;
     void initialization(size_t index_i, Real dt);
@@ -58,6 +58,25 @@ class BaseIntegration1stHalfCorrect : public BaseIntegration1stHalf<RiemannSolve
 using Integration1stHalfCorrect = BaseIntegration1stHalfCorrect<NoRiemannSolver>;
 /** define the mostly used pressure relaxation scheme using Riemann solver */
 using Integration1stHalfRiemannCorrect = BaseIntegration1stHalfCorrect<AcousticRiemannSolver>;
+
+/**
+ * @class BaseIntegration2ndHalfCorrect
+ */
+template <class RiemannSolverType>
+class BaseIntegration2ndHalfCorrect : public BaseIntegration2ndHalf<RiemannSolverType>
+{
+  public:
+    explicit BaseIntegration2ndHalfCorrect(BaseInnerRelation &inner_relation);
+
+    using BaseIntegration2ndHalf<RiemannSolverType>::BaseIntegration2ndHalf;
+    void interaction(size_t index_i, Real dt);
+
+  protected:
+    StdLargeVec<Matd> &B_;
+};
+using Integration2ndHalfCorrect = BaseIntegration2ndHalfCorrect<NoRiemannSolver>;
+/** define the mostly used pressure relaxation scheme using Riemann solver */
+using Integration2ndHalfRiemannCorrect = BaseIntegration2ndHalfCorrect<AcousticRiemannSolver>;
 } // namespace fluid_dynamics
 } // namespace SPH
 #endif // FLUID_DYNAMICS_INNER_CORRECTION_H

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner_correction.h
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner_correction.h
@@ -56,25 +56,6 @@ class BaseIntegration1stHalfCorrect : public BaseIntegration1stHalf<RiemannSolve
 using Integration1stHalfCorrect = BaseIntegration1stHalfCorrect<NoRiemannSolver>;
 /** define the mostly used pressure relaxation scheme using Riemann solver */
 using Integration1stHalfRiemannCorrect = BaseIntegration1stHalfCorrect<AcousticRiemannSolver>;
-
-/**
- * @class BaseIntegration2ndHalfCorrect
- */
-template <class RiemannSolverType>
-class BaseIntegration2ndHalfCorrect : public BaseIntegration2ndHalf<RiemannSolverType>
-{
-  public:
-    explicit BaseIntegration2ndHalfCorrect(BaseInnerRelation &inner_relation);
-
-    using BaseIntegration2ndHalf<RiemannSolverType>::BaseIntegration2ndHalf;
-    void interaction(size_t index_i, Real dt);
-
-  protected:
-    StdLargeVec<Matd> &B_;
-};
-using Integration2ndHalfCorrect = BaseIntegration2ndHalfCorrect<NoRiemannSolver>;
-/** define the mostly used pressure relaxation scheme using Riemann solver */
-using Integration2ndHalfRiemannCorrect = BaseIntegration2ndHalfCorrect<AcousticRiemannSolver>;
 } // namespace fluid_dynamics
 } // namespace SPH
 #endif // FLUID_DYNAMICS_INNER_CORRECTION_H

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner_correction.hpp
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner_correction.hpp
@@ -17,7 +17,7 @@ BaseIntegration1stHalfCorrect<RiemannSolverType>::BaseIntegration1stHalfCorrect(
 template <class RiemannSolverType>
 void BaseIntegration1stHalfCorrect<RiemannSolverType>::interaction(size_t index_i, Real dt)
 {
-    Vecd acceleration = Vecd::Zero();
+    Vecd grad_p_i = Vecd::Zero();
     Real rho_dissipation(0);
     const Neighborhood &inner_neighborhood = this->inner_configuration_[index_i];
     for (size_t n = 0; n != inner_neighborhood.current_size_; ++n)
@@ -26,10 +26,10 @@ void BaseIntegration1stHalfCorrect<RiemannSolverType>::interaction(size_t index_
         Real dW_ijV_j = inner_neighborhood.dW_ijV_j_[n];
         const Vecd &e_ij = inner_neighborhood.e_ij_[n];
 
-        acceleration -= (this->p_[index_i] * B_[index_j] + this->p_[index_j] * B_[index_i]) * dW_ijV_j * e_ij;
+        grad_p_i -= (this->p_[index_i] * B_[index_j] + this->p_[index_j] * B_[index_i]) * dW_ijV_j * e_ij;
         rho_dissipation += this->riemann_solver_.DissipativeUJump(this->p_[index_i] - this->p_[index_j]) * dW_ijV_j;
     }
-    this->acc_[index_i] += acceleration / this->rho_[index_i];
+    this->acc_[index_i] += grad_p_i / this->rho_[index_i];
     this->drho_dt_[index_i] = rho_dissipation * this->rho_[index_i];
 }
 //=================================================================================================//
@@ -42,7 +42,7 @@ template <class RiemannSolverType>
 void BaseIntegration2ndHalfCorrect<RiemannSolverType>::interaction(size_t index_i, Real dt)
 {
     Real density_change_rate(0);
-    Vecd p_dissipation = Vecd::Zero();
+    Vecd grad_p_dissipation = Vecd::Zero();
     const Neighborhood &inner_neighborhood = this->inner_configuration_[index_i];
     for (size_t n = 0; n != inner_neighborhood.current_size_; ++n)
     {
@@ -52,10 +52,10 @@ void BaseIntegration2ndHalfCorrect<RiemannSolverType>::interaction(size_t index_
 
         Real u_jump = (this->vel_[index_i] - this->vel_[index_j]).dot(e_ij_corrected);
         density_change_rate += u_jump * dW_ijV_j;
-        p_dissipation += this->riemann_solver_.DissipativePJump(u_jump) * dW_ijV_j * e_ij_corrected;
+        grad_p_dissipation += this->riemann_solver_.DissipativePJump(u_jump) * dW_ijV_j * e_ij_corrected;
     }
     this->drho_dt_[index_i] += density_change_rate * this->rho_[index_i];
-    this->acc_[index_i] = p_dissipation / this->rho_[index_i];
+    this->acc_[index_i] = grad_p_dissipation / this->rho_[index_i];
 }
 //=================================================================================================//
 } // namespace fluid_dynamics

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner_correction.hpp
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner_correction.hpp
@@ -41,5 +41,30 @@ void BaseIntegration1stHalfCorrect<RiemannSolverType>::interaction(size_t index_
     this->drho_dt_[index_i] = rho_dissipation * this->rho_[index_i];
 }
 //=================================================================================================//
+template <class RiemannSolverType>
+BaseIntegration2ndHalfCorrect<RiemannSolverType>::BaseIntegration2ndHalfCorrect(BaseInnerRelation &inner_relation)
+    : BaseIntegration2ndHalf<RiemannSolverType>(inner_relation),
+      B_(*this->particles_->template registerSharedVariable<Matd>("CorrectionMatrix", Matd::Identity())) {}
+//=================================================================================================//
+template <class RiemannSolverType>
+void BaseIntegration2ndHalfCorrect<RiemannSolverType>::interaction(size_t index_i, Real dt)
+{
+    Real density_change_rate(0);
+    Vecd p_dissipation = Vecd::Zero();
+    const Neighborhood &inner_neighborhood = this->inner_configuration_[index_i];
+    for (size_t n = 0; n != inner_neighborhood.current_size_; ++n)
+    {
+        size_t index_j = inner_neighborhood.j_[n];
+        const Vecd e_ij_corrected = B_[index_i] * inner_neighborhood.e_ij_[n];
+        Real dW_ijV_j = inner_neighborhood.dW_ijV_j_[n];
+
+        Real u_jump = (this->vel_[index_i] - this->vel_[index_j]).dot(e_ij_corrected);
+        density_change_rate += u_jump * dW_ijV_j;
+        p_dissipation += this->riemann_solver_.DissipativePJump(u_jump) * dW_ijV_j * e_ij_corrected;
+    }
+    this->drho_dt_[index_i] += density_change_rate * this->rho_[index_i];
+    this->acc_[index_i] = p_dissipation / this->rho_[index_i];
+}
+//=================================================================================================//
 } // namespace fluid_dynamics
 } // namespace SPH

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner_correction.hpp
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner_correction.hpp
@@ -33,30 +33,5 @@ void BaseIntegration1stHalfCorrect<RiemannSolverType>::interaction(size_t index_
     this->drho_dt_[index_i] = rho_dissipation * this->rho_[index_i];
 }
 //=================================================================================================//
-template <class RiemannSolverType>
-BaseIntegration2ndHalfCorrect<RiemannSolverType>::BaseIntegration2ndHalfCorrect(BaseInnerRelation &inner_relation)
-    : BaseIntegration2ndHalf<RiemannSolverType>(inner_relation),
-      B_(*this->particles_->template registerSharedVariable<Matd>("CorrectionMatrix", Matd::Identity())) {}
-//=================================================================================================//
-template <class RiemannSolverType>
-void BaseIntegration2ndHalfCorrect<RiemannSolverType>::interaction(size_t index_i, Real dt)
-{
-    Real density_change_rate(0);
-    Vecd grad_p_dissipation = Vecd::Zero();
-    const Neighborhood &inner_neighborhood = this->inner_configuration_[index_i];
-    for (size_t n = 0; n != inner_neighborhood.current_size_; ++n)
-    {
-        size_t index_j = inner_neighborhood.j_[n];
-        const Vecd e_ij_corrected = B_[index_i] * inner_neighborhood.e_ij_[n];
-        Real dW_ijV_j = inner_neighborhood.dW_ijV_j_[n];
-
-        Real u_jump = (this->vel_[index_i] - this->vel_[index_j]).dot(e_ij_corrected);
-        density_change_rate += u_jump * dW_ijV_j;
-        grad_p_dissipation += this->riemann_solver_.DissipativePJump(u_jump) * dW_ijV_j * e_ij_corrected;
-    }
-    this->drho_dt_[index_i] += density_change_rate * this->rho_[index_i];
-    this->acc_[index_i] = grad_p_dissipation / this->rho_[index_i];
-}
-//=================================================================================================//
 } // namespace fluid_dynamics
 } // namespace SPH

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner_correction.hpp
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner_correction.hpp
@@ -12,14 +12,6 @@ BaseIntegration1stHalfCorrect<RiemannSolverType>::BaseIntegration1stHalfCorrect(
     : BaseIntegration1stHalf<RiemannSolverType>(inner_relation),
       B_(*this->particles_->template registerSharedVariable<Matd>("CorrectionMatrix", Matd::Identity()))
 {
-    this->particles_->registerVariable(p_B_, "CorrectedPressure");
-}
-//=================================================================================================//
-template <class RiemannSolverType>
-void BaseIntegration1stHalfCorrect<RiemannSolverType>::initialization(size_t index_i, Real dt)
-{
-    BaseIntegration1stHalf<RiemannSolverType>::initialization(index_i, dt);
-    p_B_[index_i] = this->p_[index_i] * this->B_[index_i];
 }
 //=================================================================================================//
 template <class RiemannSolverType>
@@ -34,7 +26,7 @@ void BaseIntegration1stHalfCorrect<RiemannSolverType>::interaction(size_t index_
         Real dW_ijV_j = inner_neighborhood.dW_ijV_j_[n];
         const Vecd &e_ij = inner_neighborhood.e_ij_[n];
 
-        acceleration -= (p_B_[index_i] + p_B_[index_j]) * dW_ijV_j * e_ij;
+        acceleration -= (this->p_[index_i] * B_[index_j] + this->p_[index_j] * B_[index_i]) * dW_ijV_j * e_ij;
         rho_dissipation += this->riemann_solver_.DissipativeUJump(this->p_[index_i] - this->p_[index_j]) * dW_ijV_j;
     }
     this->acc_[index_i] += acceleration / this->rho_[index_i];

--- a/src/shared/particle_dynamics/general_dynamics/general_interaction.cpp
+++ b/src/shared/particle_dynamics/general_dynamics/general_interaction.cpp
@@ -9,7 +9,7 @@ CorrectedConfigurationInner::
     : LocalDynamics(inner_relation.getSPHBody()),
       GeneralDataDelegateInner(inner_relation),
       beta_(beta), alpha_(alpha),
-      B_(*particles_->getVariableByName<Matd>("CorrectionMatrix")) {}
+      B_(*particles_->registerSharedVariable<Matd>("CorrectionMatrix", Matd::Identity())) {}
 //=================================================================================================//
 void CorrectedConfigurationInner::interaction(size_t index_i, Real dt)
 {


### PR DESCRIPTION
Virtosim: [593](https://github.com/virtonomy-dev/virtosim/pull/593)
Not updated yet due to package conflicts on my Ubuntu.

This PR includes two changes:
1. Update `Integration1stHalfRiemannCorrect` algorithm according to the head of SPHinXsys
2. Register shared variable in `CorrectedConfigurationComplex`, so that we don't need to manually register `B_` for fluid

Usage:
```
Dynamics1Level<fluid_dynamics::Integration1stHalfRiemannCorrectWithWall> pressure_relaxation(fluid_block_complex);
Dynamics1Level<fluid_dynamics::Integration2ndHalfCorrectWithWall> density_relaxation(fluid_block_complex);
InteractionWithUpdate<virtonomy::CorrectedConfigurationComplexWithoutEmitter> corrected_config(fluid_block_complex, 0.0, 0.1);
```
Run `corrected_config` in each advective step.

For fluid force on solid:

```
InteractionDynamics<virtonomy::AllForceAccelerationFromFluidCorrect> fluid_force_on_wall(
        to_wall_from_fluid_contact, viscous_force_on_solid
    );
```
when fluid 2nd half integration is without Riemann, 

or 

```
InteractionDynamics<virtonomy::AllForceAccelerationFromFluidCorrectRiemann> fluid_force_on_wall(
        to_wall_from_fluid_contact, viscous_force_on_solid
    );
```
when fluid 2nd half integration is with Riemann.