### PR TITLE
Riemann stabilization

### DIFF
--- a/src/shared/particle_dynamics/solid_dynamics/elastic_dynamics.cpp
+++ b/src/shared/particle_dynamics/solid_dynamics/elastic_dynamics.cpp
@@ -63,15 +63,14 @@ void BaseIntegration1stHalf::update(size_t index_i, Real dt)
 }
 //=================================================================================================//
 Integration1stHalf::
-    Integration1stHalf(BaseInnerRelation &inner_relation, Real numerical_dissipation_factor)
-    : BaseIntegration1stHalf(inner_relation),
-      numerical_dissipation_factor_(numerical_dissipation_factor)
+    Integration1stHalf(BaseInnerRelation &inner_relation)
+    : BaseIntegration1stHalf(inner_relation)
 {
     particles_->registerVariable(stress_PK1_B_, "CorrectedStressPK1");
 }
 //=================================================================================================//
-Integration1stHalfPK2::Integration1stHalfPK2(BaseInnerRelation &inner_relation, Real numerical_dissipation_factor)
-    : Integration1stHalf(inner_relation, numerical_dissipation_factor) {};
+Integration1stHalfPK2::Integration1stHalfPK2(BaseInnerRelation &inner_relation)
+    : Integration1stHalf(inner_relation) {};
 //=================================================================================================//
 void Integration1stHalfPK2::initialization(size_t index_i, Real dt)
 {
@@ -84,8 +83,8 @@ void Integration1stHalfPK2::initialization(size_t index_i, Real dt)
 }
 //=================================================================================================//
 Integration1stHalfKirchhoff::
-    Integration1stHalfKirchhoff(BaseInnerRelation &inner_relation, Real numerical_dissipation_factor)
-    : Integration1stHalf(inner_relation, numerical_dissipation_factor) {};
+    Integration1stHalfKirchhoff(BaseInnerRelation &inner_relation)
+    : Integration1stHalf(inner_relation) {};
 //=================================================================================================//
 void Integration1stHalfKirchhoff::initialization(size_t index_i, Real dt)
 {
@@ -108,8 +107,8 @@ void Integration1stHalfKirchhoff::initialization(size_t index_i, Real dt)
 }
 //=================================================================================================//
 Integration1stHalfCauchy::
-    Integration1stHalfCauchy(BaseInnerRelation &inner_relation, Real numerical_dissipation_factor)
-    : Integration1stHalf(inner_relation, numerical_dissipation_factor) {}
+    Integration1stHalfCauchy(BaseInnerRelation &inner_relation)
+    : Integration1stHalf(inner_relation) {}
 //=================================================================================================//
 void Integration1stHalfCauchy::initialization(size_t index_i, Real dt)
 {

--- a/src/shared/particle_dynamics/solid_dynamics/elastic_dynamics.h
+++ b/src/shared/particle_dynamics/solid_dynamics/elastic_dynamics.h
@@ -175,10 +175,7 @@ class BaseIntegration1stHalf : public BaseElasticIntegration
 class Integration1stHalf : public BaseIntegration1stHalf
 {
   public:
-    // The numerical dissipation factor is used to increase the numerical stability of the solid, which is between 0 and 1
-    // The default value is set to 0.25, which is a common choice in practice.
-    // For soft solids in FSI simulations, a larger numerical dissipation factor may be needed to maintain stability
-    explicit Integration1stHalf(BaseInnerRelation &inner_relation, Real numerical_dissipation_factor);
+    explicit Integration1stHalf(BaseInnerRelation &inner_relation);
     virtual ~Integration1stHalf() {};
 
     inline void interaction(size_t index_i, Real dt = 0.0)
@@ -189,19 +186,26 @@ class Integration1stHalf : public BaseIntegration1stHalf
         for (size_t n = 0; n != inner_neighborhood.current_size_; ++n)
         {
             size_t index_j = inner_neighborhood.j_[n];
-            Vecd e_ij = inner_neighborhood.e_ij_[n];
-            Real r_ij = inner_neighborhood.r_ij_[n];
-            Real dim_r_ij_1 = Dimensions / r_ij;
-            Vecd pos_jump = pos_[index_i] - pos_[index_j];
-            Vecd vel_jump = vel_[index_i] - vel_[index_j];
-            Real strain_rate = dim_r_ij_1 * dim_r_ij_1 * pos_jump.dot(vel_jump);
-            Real weight = inner_neighborhood.W_ij_[n] * inv_W0_;
-            Matd numerical_stress_ij =
-                0.5 * (F_[index_i] + F_[index_j]) * elastic_solid_.PairNumericalDamping(strain_rate, smoothing_length_);
+            Vecd e_ij_0 = inner_neighborhood.e_ij_[n];
+
+            auto numerical_stress = [&]() -> Matd
+            {
+                Real c_cp = elastic_solid_.ReferenceSoundSpeed();
+                Real c_sh = elastic_solid_.ShearWaveSpeed();
+                Vecd r_ji_0 = -inner_neighborhood.r_ij_[n] * e_ij_0;
+                Vecd e_ji = (pos_[index_j] - pos_[index_i]).normalized();
+                Matd e_ji_eji = e_ji * e_ji.transpose();
+                Vecd ui_R = vel_[index_i] + 0.5 * dF_dt_[index_i] * r_ji_0;
+                Vecd uj_R = vel_[index_j] - 0.5 * dF_dt_[index_j] * r_ji_0;
+                Vecd u_ji_R = uj_R - ui_R;
+                // only activate numerical dissipation when the particle pair is approaching
+                // double beta = SMAX(Real(0), SGN(-u_ji_R.dot(e_ji)));
+                return -0.5 * (c_cp * e_ji_eji + c_sh * (Matd::Identity() - e_ji_eji)) * rho0_ * u_ji_R * e_ij_0.transpose();
+            }();
+
             acceleration += inv_rho0_ * inner_neighborhood.dW_ijV_j_[n] *
-                            (stress_PK1_B_[index_i] + stress_PK1_B_[index_j] +
-                             numerical_dissipation_factor_ * weight * numerical_stress_ij) *
-                            e_ij;
+                            (stress_PK1_B_[index_i] + stress_PK1_B_[index_j] + numerical_stress) *
+                            e_ij_0;
         }
 
         acc_[index_i] = acceleration;
@@ -220,7 +224,7 @@ class Integration1stHalf : public BaseIntegration1stHalf
 class Integration1stHalfPK2 : public Integration1stHalf
 {
   public:
-    explicit Integration1stHalfPK2(BaseInnerRelation &inner_relation, Real numerical_dissipation_factor = 0.25);
+    explicit Integration1stHalfPK2(BaseInnerRelation &inner_relation);
     virtual ~Integration1stHalfPK2() {};
     void initialization(size_t index_i, Real dt = 0.0);
 };
@@ -231,7 +235,7 @@ class Integration1stHalfPK2 : public Integration1stHalf
 class Integration1stHalfCauchy : public Integration1stHalf
 {
   public:
-    explicit Integration1stHalfCauchy(BaseInnerRelation &inner_relation, Real numerical_dissipation_factor = 0.25);
+    explicit Integration1stHalfCauchy(BaseInnerRelation &inner_relation);
     virtual ~Integration1stHalfCauchy() {};
     void initialization(size_t index_i, Real dt = 0.0);
 };
@@ -243,7 +247,7 @@ class Integration1stHalfCauchy : public Integration1stHalf
 class Integration1stHalfKirchhoff : public Integration1stHalf
 {
   public:
-    explicit Integration1stHalfKirchhoff(BaseInnerRelation &inner_relation, Real numerical_dissipation_factor = 0.25);
+    explicit Integration1stHalfKirchhoff(BaseInnerRelation &inner_relation);
     virtual ~Integration1stHalfKirchhoff() {};
     void initialization(size_t index_i, Real dt = 0.0);
 };

--- a/src/shared/particle_dynamics/solid_dynamics/elastic_dynamics.h
+++ b/src/shared/particle_dynamics/solid_dynamics/elastic_dynamics.h
@@ -213,8 +213,6 @@ class Integration1stHalf : public BaseIntegration1stHalf
 
   protected:
     StdLargeVec<Matd> stress_PK1_B_;
-    Real numerical_dissipation_factor_;
-    Real inv_W0_ = 1.0 / sph_body_.sph_adaptation_->getKernel()->W0(ZeroVecd);
 };
 
 /**

--- a/src/shared/particle_dynamics/solid_dynamics/elastic_dynamics.h
+++ b/src/shared/particle_dynamics/solid_dynamics/elastic_dynamics.h
@@ -27,8 +27,8 @@
  * @author	Chi Zhang and Xiangyu Hu
  */
 
-#ifndef ELASTIC_DYNAMICS_H
-#define ELASTIC_DYNAMICS_H
+#ifndef VIRTOSIM_ELASTIC_DYNAMICS_H_D5C7BFAF_09FC_4074_84D4_BB57619CD17C
+#define VIRTOSIM_ELASTIC_DYNAMICS_H_D5C7BFAF_09FC_4074_84D4_BB57619CD17C
 
 #include "all_body_relations.h"
 #include "all_particle_dynamics.h"
@@ -186,26 +186,41 @@ class Integration1stHalf : public BaseIntegration1stHalf
         for (size_t n = 0; n != inner_neighborhood.current_size_; ++n)
         {
             size_t index_j = inner_neighborhood.j_[n];
-            Vecd e_ij_0 = inner_neighborhood.e_ij_[n];
+            Vecd grad_W_ij0V_j0 = inner_neighborhood.dW_ijV_j_[n] * inner_neighborhood.e_ij_[n];
+            acceleration += inv_rho0_ * (stress_PK1_B_[index_i] + stress_PK1_B_[index_j]) * grad_W_ij0V_j0;
 
-            auto numerical_stress = [&]() -> Matd
+            // See ref: Gotoh, Takafumi & Sakoda, Daiki & Khayyer, Abbas & Lee, Chun Hean & Gil, Antonio & Gotoh, Hitoshi & Bonet, Javier. (2025). An enhanced total Lagrangian SPH for non-linear and finite strain elastic structural dynamics. Computational Mechanics. 76. 147-179. 10.1007/s00466-024-02592-z.
+            // Equation (26): a_i = sum_j 0.5 * beta * (c_cp * e_ij \otimes e_ij + c_sh * (I - e_ij \otimes eij)) * u_ij_R \otimes e_ij_0 * grad0W_0ijV_0j
+            // The notation is different from sphinxsys, with r_ij = r_j - r_i and u_ij = u_j - u_i
+            // Inside the lambda function, we follow the notation of the paper
+
+            // Definition of r_ij is r_j - r_i, see the paragraph below equation (8) in the paper
+            // e_ij_0 is hence defined as (r_j0 - r_i0) / |r_j0 - r_i0|, which is equivalent to -inner_neighborhood.e_ij_[n] since inner_neighborhood.e_ij_[n] is defined as (r_i0 - r_j0) / |r_i0 - r_j0|
+            Vecd e_ij_0 = -inner_neighborhood.e_ij_[n];
+
+            auto numerical_acc = [&]() -> Vecd
             {
-                Real c_cp = elastic_solid_.ReferenceSoundSpeed();
-                Real c_sh = elastic_solid_.ShearWaveSpeed();
-                Vecd r_ji_0 = -inner_neighborhood.r_ij_[n] * e_ij_0;
-                Vecd e_ji = (pos_[index_j] - pos_[index_i]).normalized();
-                Matd e_ji_eji = e_ji * e_ji.transpose();
-                Vecd ui_R = vel_[index_i] + 0.5 * dF_dt_[index_i] * r_ji_0;
-                Vecd uj_R = vel_[index_j] - 0.5 * dF_dt_[index_j] * r_ji_0;
-                Vecd u_ji_R = uj_R - ui_R;
+                Real c_cp = elastic_solid_.ReferenceSoundSpeed(); // pressure wave speed
+                Real c_sh = elastic_solid_.ShearWaveSpeed();      // shear wave speed
+
+                Vecd e_ij = (pos_[index_j] - pos_[index_i]).normalized(); // equivalent to r_ij / r_ij.norm() in the equation
+                Matd e_ij_eij = e_ij * e_ij.transpose();
+
+                // See equation (18)
+                Vecd r_ij_0 = inner_neighborhood.r_ij_[n] * e_ij_0; // r_ij_0 = r_j0 - r_i0
+                Vecd ui_R = vel_[index_i] + 0.5 * dF_dt_[index_i] * r_ij_0;
+                Vecd uj_R = vel_[index_j] - 0.5 * dF_dt_[index_j] * r_ij_0;
+                Vecd u_ij_R = uj_R - ui_R;
+
                 // only activate numerical dissipation when the particle pair is approaching
-                // double beta = SMAX(Real(0), SGN(-u_ji_R.dot(e_ji)));
-                return -0.5 * (c_cp * e_ji_eji + c_sh * (Matd::Identity() - e_ji_eji)) * rho0_ * u_ji_R * e_ij_0.transpose();
+                // See equation (17)
+                // Vecd u_ji_R = -u_ij_R;
+                // Real u_ji_R_dot_e_ij = u_ji_R.dot(e_ij);
+                // Real beta = SMAX(Real(0), u_ji_R_dot_e_ij / abs(u_ji_R_dot_e_ij));
+                return (0.5 * (c_cp * e_ij_eij + c_sh * (Matd::Identity() - e_ij_eij)) * u_ij_R * e_ij_0.transpose()) * grad_W_ij0V_j0;
             }();
 
-            acceleration += inv_rho0_ * inner_neighborhood.dW_ijV_j_[n] *
-                            (stress_PK1_B_[index_i] + stress_PK1_B_[index_j] + numerical_stress) *
-                            e_ij_0;
+            acceleration += numerical_acc;
         }
 
         acc_[index_i] = acceleration;
@@ -329,4 +344,4 @@ class Integration2ndHalf : public BaseElasticIntegration
 };
 } // namespace solid_dynamics
 } // namespace SPH
-#endif // ELASTIC_DYNAMICS_H
+#endif // VIRTOSIM_ELASTIC_DYNAMICS_H_D5C7BFAF_09FC_4074_84D4_BB57619CD17C

--- a/src/shared/particle_dynamics/solid_dynamics/inelastic_dynamics.cpp
+++ b/src/shared/particle_dynamics/solid_dynamics/inelastic_dynamics.cpp
@@ -10,7 +10,6 @@ PlasticIntegration1stHalf::
     PlasticIntegration1stHalf(BaseInnerRelation &inner_relation) : Integration1stHalf(inner_relation),
                                                                    plastic_solid_(DynamicCast<PlasticSolid>(this, elastic_solid_))
 {
-    numerical_dissipation_factor_ = 0.5;
 }
 //=================================================================================================//
 void PlasticIntegration1stHalf::initialization(size_t index_i, Real dt)


### PR DESCRIPTION
Reference: [DOI:10.1007/s00466-024-02592-z](https://eprints.gla.ac.uk/351804/2/351804.pdf), An enhanced total Lagrangian SPH for non-linear and finite strain elastic structural dynamics

See equation (26):
<img width="950" height="92" alt="image" src="https://github.com/user-attachments/assets/c73d00a3-a58b-41e2-aa76-288a4aa3f48c" />

with pressure wave and shear wave defined as:
<img width="275" height="110" alt="image" src="https://github.com/user-attachments/assets/578fc600-328a-417a-a2c8-ab1bddb3e2d4" />

Note that the definition of $\mathbf{r_ij} = \mathbf{r_j} - \mathbf{r_i}$ and $\mathbf{u_ij} = \mathbf{u_j} - \mathbf{u_i}$ are different from the ones in SPHinXsys. 

The values with the superscript $R$ are defined as:

<img width="951" height="64" alt="image" src="https://github.com/user-attachments/assets/9d7b1ff0-adc4-4cc3-9991-de3d4865af20" />

I used `dF_dt_` for the gradient of velocity $\nabla^0 \mathbf{u}$ in this equation.

The limiter $\beta$ ensures that the stabilization term is only used when a pair of particles is approaching, but it seems that without the limiter, it performs better.
<img width="952" height="122" alt="image" src="https://github.com/user-attachments/assets/63c754d2-da0d-4c07-95c3-9ada758f0afc" />

 **Warning** 

This dissipation term assumes the material is homogeneous, so it cannot be directly applied to the composite material, but the numerical term in SPHinXsys also has this problem.