### PR TITLE
Exponential method to update e33

### DIFF
--- a/src/shared/particle_dynamics/solid_dynamics/thin_structure_dynamics.cpp
+++ b/src/shared/particle_dynamics/solid_dynamics/thin_structure_dynamics.cpp
@@ -145,7 +145,7 @@ void ShellStressRelaxationFirstHalf::initialization(size_t index_i, Real dt)
           /// Differential geometry and the geometrically non-linear Reissner-Mindlin shell model
           /// @WARN Algorithm is not guaranteed to converge, see discussion in Sec. 5.4.1
           ///       even more so considering we do not reuse analytical derivatives.
-
+            // Based on the Cauchy stress and the inverse left Cauchy-Green tensor c = I-2*almansi_strain
             // Initial secant is based on the linear elastic model
             double slope = -0.5 * (elastic_solid_.BulkModulus() + 4.0 / 3.0 * elastic_solid_.ShearModulus());
             int it = 0;
@@ -160,17 +160,17 @@ void ShellStressRelaxationFirstHalf::initialization(size_t index_i, Real dt)
                  ++it)
             {
                 double s_prev = cauchy_stress(2, 2);
-                Matd inv_B = -2.0 * current_local_almansi_strain + Matd::Identity();
-                double inv_b_prev = inv_B(2, 2);
-                double d_inv_b = -s_prev / slope;
-                double det_inv_B = inv_B.determinant();
-                double m_12 = inv_B.block<2, 2>(0, 0).determinant();
-                double inv_b_next = inv_b_prev + det_inv_B * std::expm1(d_inv_b * m_12 / det_inv_B) / m_12;
-                double e_next = 0.5 * (1.0 - inv_b_next);
+                Matd c = -2.0 * current_local_almansi_strain + Matd::Identity();
+                double c_prev = c(2, 2);
+                double d_c = -s_prev / slope;
+                double det_c = c.determinant();
+                double m_12 = c.block<2, 2>(0, 0).determinant();
+                double c_next = c_prev + det_c * std::expm1(d_c * m_12 / det_c) / m_12;
+                double e_next = 0.5 * (1.0 - c_next);
                 current_local_almansi_strain(2, 2) = e_next;
                 cauchy_stress = elastic_solid_.StressCauchy(current_local_almansi_strain, F_gaussian_point, index_i);
                 s_next = cauchy_stress(2, 2);
-                slope = (s_next - s_prev) / (inv_b_next - inv_b_prev);
+                slope = (s_next - s_prev) / (c_next - c_prev);
             }
             if (cauchy_stress.allFinite() == false || it == max_iterations)
                 throw std::runtime_error("[ShellStressRelaxationFirstHalf::initialization] Enforcing plane stress condition failed for particle with unsorted_id: " + std::to_string(unsorted_id_[index_i]) + " in object: " + sph_body_.getName() + "\nWith normal stress in the out-of-plane direction: " + std::to_string(cauchy_stress(2, 2)));

--- a/src/shared/particle_dynamics/solid_dynamics/thin_structure_dynamics.cpp
+++ b/src/shared/particle_dynamics/solid_dynamics/thin_structure_dynamics.cpp
@@ -146,7 +146,8 @@ void ShellStressRelaxationFirstHalf::initialization(size_t index_i, Real dt)
           /// @WARN Algorithm is not guaranteed to converge, see discussion in Sec. 5.4.1
           ///       even more so considering we do not reuse analytical derivatives.
 
-            double E = E0_; // Take the default Young's modulus of the material as the initial derivative.
+            // Initial secant is based on the linear elastic model
+            double slope = -0.5 * (elastic_solid_.BulkModulus() + 4.0 / 3.0 * elastic_solid_.ShearModulus());
             int it = 0;
             constexpr int max_iterations = 20; // @WARN hard-coded maximum number of iterations
             constexpr auto infinity = std::numeric_limits<Real>::infinity();
@@ -158,17 +159,21 @@ void ShellStressRelaxationFirstHalf::initialization(size_t index_i, Real dt)
                  s_next * s_next > tolerance_sqr(cauchy_stress) && it < max_iterations;
                  ++it)
             {
-                double e_prev = current_local_almansi_strain(2, 2);
                 double s_prev = cauchy_stress(2, 2);
-                double e_next = e_prev - s_prev / E;
+                Matd inv_B = -2.0 * current_local_almansi_strain + Matd::Identity();
+                double inv_b_prev = inv_B(2, 2);
+                double d_inv_b = -s_prev / slope;
+                double det_inv_B = inv_B.determinant();
+                double m_12 = inv_B.block<2, 2>(0, 0).determinant();
+                double inv_b_next = inv_b_prev + det_inv_B * std::expm1(d_inv_b * m_12 / det_inv_B) / m_12;
+                double e_next = 0.5 * (1.0 - inv_b_next);
                 current_local_almansi_strain(2, 2) = e_next;
                 cauchy_stress = elastic_solid_.StressCauchy(current_local_almansi_strain, F_gaussian_point, index_i);
                 s_next = cauchy_stress(2, 2);
-                E = (s_next - s_prev) / (e_next - e_prev);
+                slope = (s_next - s_prev) / (inv_b_next - inv_b_prev);
             }
             if (cauchy_stress.allFinite() == false || it == max_iterations)
                 throw std::runtime_error("[ShellStressRelaxationFirstHalf::initialization] Enforcing plane stress condition failed for particle with unsorted_id: " + std::to_string(unsorted_id_[index_i]) + " in object: " + sph_body_.getName() + "\nWith normal stress in the out-of-plane direction: " + std::to_string(cauchy_stress(2, 2)));
-
         }
         /// Impact of including numerical damping in the algorithm above unclear
         /// Left here in absence of discriminating factors


### PR DESCRIPTION
Ref: [Differential geometry and the geometrically non-linear Reissner-Mindlin shell model](http://dx.doi.org/10.18419/opus-14215)

The reference paper is based on the right Cauchy Green tensor and the PK2 stress. To enforce the condition
<img width="766" height="89" alt="image" src="https://github.com/user-attachments/assets/59b0be04-3b76-421e-96a1-fcd15de78fab" />

The right Cauchy Green tensor is updated by:
<img width="756" height="82" alt="image" src="https://github.com/user-attachments/assets/8302ffa0-648d-49c6-a4d1-215dee930132" />

with $m_{12}$ defined as:
<img width="623" height="34" alt="image" src="https://github.com/user-attachments/assets/7defa33c-ccb2-489b-9837-a4dd2f9c5d90" />

The increment $\Delta C_{33}$ is given by:
<img width="758" height="67" alt="image" src="https://github.com/user-attachments/assets/25df613e-f97f-42cd-8568-05ed77177e13" />

According to the paper, this method has a lower risk of violating the positive definiteness of the predicted right Cauchy Green stress in comparison to the linear Newton method.

## Adapted to Almansi strain and Cauchy stress
As the shell algorithm in SPHinXsys is based on the Almansi strain and Cauchy stress, the algorithm can be reformulated based on the inverse of the left Cauchy Green tensor $\mathbf{c} = \mathbf{I} - 2\mathbf{e}$ and Cauchy stress $\boldsymbol{\sigma}$:

```math
\sigma_{i+1}^{33}=\sigma_{i}^{33} + \frac{\partial \sigma^{33}}{\partial c_{33}}|_i \Delta c_{33}
```

The inverse left Cauchy is updated by:

```math
c_{33}^{i+1}=c_{33}^{i} + \frac{\det(\mathbf{c^i})}{m_{12}}[\exp(\frac{\Delta c_{33} m_{12}}{\det(\mathbf{c^i})})-1]
```
```math
\Delta c_{33} = -\frac{\sigma_{i}^{33}}{ \frac{\partial \sigma^{33}}{\partial c_{33}}|_i}
```

As we don't have the second order derivative of the stress, here we use the secant to approximate $\frac{\partial \sigma^{33}}{\partial c_{33}}|_i $. 

```math
\frac{\partial \sigma^{33}}{\partial c_{33}}|_i = \frac{\sigma_{i}^{33} - \sigma_{i-1}^{33}}{c_{33}^{i} - c_{33}^{i-1}}
```

The initial value is approximated as $-\frac{1}{2}(\lambda+2\mu)$ based on the linear elastic model.
