### PR TITLE
Fix shell initial guess

### DIFF
--- a/src/shared/particle_dynamics/solid_dynamics/thin_structure_dynamics.cpp
+++ b/src/shared/particle_dynamics/solid_dynamics/thin_structure_dynamics.cpp
@@ -142,11 +142,11 @@ void ShellStressRelaxationFirstHalf::initialization(size_t index_i, Real dt)
         current_local_almansi_strain(2, 2) = 0;
         Matd cauchy_stress = elastic_solid_.StressCauchy(current_local_almansi_strain, F_gaussian_point, index_i);
         { /// Enforce plane stress condition adapting algorithm from Sec. 5.4.1 from http://dx.doi.org/10.18419/opus-14215
-          /// Differential geometry and the geometrically non-linear Reissner-Mindlin shell model
-          /// @WARN Algorithm is not guaranteed to converge, see discussion in Sec. 5.4.1
-          ///       even more so considering we do not reuse analytical derivatives.
-
-            double E = E0_; // Take the default Young's modulus of the material as the initial derivative.
+            /// Differential geometry and the geometrically non-linear Reissner-Mindlin shell model
+            /// @WARN Algorithm is not guaranteed to converge, see discussion in Sec. 5.4.1
+            ///       even more so considering we do not reuse analytical derivatives.
+            // Take lambda + 2mu as the initial derivative based on the linear material
+            double ds_de = elastic_solid_.BulkModulus() + 4.0 / 3.0 * elastic_solid_.ShearModulus();
             int it = 0;
             constexpr int max_iterations = 20; // @WARN hard-coded maximum number of iterations
             constexpr auto infinity = std::numeric_limits<Real>::infinity();
@@ -160,15 +160,14 @@ void ShellStressRelaxationFirstHalf::initialization(size_t index_i, Real dt)
             {
                 double e_prev = current_local_almansi_strain(2, 2);
                 double s_prev = cauchy_stress(2, 2);
-                double e_next = e_prev - s_prev / E;
+                double e_next = e_prev - s_prev / ds_de;
                 current_local_almansi_strain(2, 2) = e_next;
                 cauchy_stress = elastic_solid_.StressCauchy(current_local_almansi_strain, F_gaussian_point, index_i);
                 s_next = cauchy_stress(2, 2);
-                E = (s_next - s_prev) / (e_next - e_prev);
+                ds_de = (s_next - s_prev) / (e_next - e_prev);
             }
             if (cauchy_stress.allFinite() == false || it == max_iterations)
                 throw std::runtime_error("[ShellStressRelaxationFirstHalf::initialization] Enforcing plane stress condition failed for particle with unsorted_id: " + std::to_string(unsorted_id_[index_i]) + " in object: " + sph_body_.getName() + "\nWith normal stress in the out-of-plane direction: " + std::to_string(cauchy_stress(2, 2)));
-
         }
         /// Impact of including numerical damping in the algorithm above unclear
         /// Left here in absence of discriminating factors

--- a/src/shared/particles/solid_particles.cpp
+++ b/src/shared/particles/solid_particles.cpp
@@ -10,14 +10,17 @@ namespace SPH
 {
 //=============================================================================================//
 SolidParticles::SolidParticles(SPHBody &sph_body, Solid *solid)
-		: BaseParticles(sph_body, solid), solid_(*solid) {}
+    : BaseParticles(sph_body, solid), solid_data_(solid), solid_(*solid_data_) {}
+
+SolidParticles::SolidParticles(SPHBody &sph_body, BaseMaterial *solid)
+    : BaseParticles(sph_body, solid), solid_data_(dynamic_cast<Solid *>(solid)), solid_(*solid_data_) {}
 //=================================================================================================//
 void SolidParticles::initializeOtherVariables()
 {
-		BaseParticles::initializeOtherVariables();
+    BaseParticles::initializeOtherVariables();
     registerVariable(pos0_, "InitialPosition", [&](size_t i) -> Vecd
                      { return pos_[i]; });
-		registerVariable(n_, "NormalDirection");
+    registerVariable(n_, "NormalDirection");
     registerVariable(n0_, "InitialNormalDirection", [&](size_t i) -> Vecd
                      { return n_[i]; });
     registerVariable(B_, "CorrectionMatrix", [&](size_t i) -> Matd
@@ -25,244 +28,248 @@ void SolidParticles::initializeOtherVariables()
 }
 //=============================================================================================//
 ElasticSolidParticles::
-		ElasticSolidParticles(SPHBody &sph_body, ElasticSolid *elastic_solid)
-		: SolidParticles(sph_body, elastic_solid),
-		  elastic_solid_(*elastic_solid) {}
+    ElasticSolidParticles(SPHBody &sph_body, ElasticSolid *elastic_solid)
+    : SolidParticles(sph_body, elastic_solid), elastic_solid_data_(elastic_solid), elastic_solid_(*elastic_solid_data_) {}
+
+ElasticSolidParticles::
+    ElasticSolidParticles(SPHBody &sph_body, BaseMaterial *elastic_solid)
+    : SolidParticles(sph_body, elastic_solid), elastic_solid_data_(dynamic_cast<ElasticSolid *>(elastic_solid)), elastic_solid_(*elastic_solid_data_) {}
+
 //=================================================================================================//
 void ElasticSolidParticles::initializeOtherVariables()
 {
-		SolidParticles::initializeOtherVariables();
-		/**
-		 *	register particle data
-		 */
+    SolidParticles::initializeOtherVariables();
+    /**
+     *	register particle data
+     */
     registerVariable(F_, "DeformationGradient", [&](size_t i) -> Matd
                      { return Matd::Identity(); });
-		registerVariable(dF_dt_, "DeformationRate");
-		/**
-		 *	register FSI data
-		 */
-		registerVariable(vel_ave_, "AverageVelocity");
-		registerVariable(acc_ave_, "AverageAcceleration");
-		/**
-		 *	add restart output particle data
-		 */
-		addVariableToRestart<Matd>("DeformationGradient");
-		/**
-		 *	add restart output particle data
+    registerVariable(dF_dt_, "DeformationRate");
+    /**
+     *	register FSI data
      */
-		addVariableToWrite<Vecd>("NormalDirection");
-		addDerivedVariableToWrite<Displacement>();
-		addDerivedVariableToWrite<VonMisesStress>();
-		addDerivedVariableToWrite<VonMisesStrain>();
-		addVariableToRestart<Matd>("DeformationGradient");
-		// get which stress measure is relevant for the material
-		stress_measure_ = elastic_solid_.getRelevantStressMeasureName();
+    registerVariable(vel_ave_, "AverageVelocity");
+    registerVariable(acc_ave_, "AverageAcceleration");
+    /**
+     *	add restart output particle data
+     */
+    addVariableToRestart<Matd>("DeformationGradient");
+    /**
+     *	add restart output particle data
+     */
+    addVariableToWrite<Vecd>("NormalDirection");
+    addDerivedVariableToWrite<Displacement>();
+    addDerivedVariableToWrite<VonMisesStress>();
+    addDerivedVariableToWrite<VonMisesStrain>();
+    addVariableToRestart<Matd>("DeformationGradient");
+    // get which stress measure is relevant for the material
+    stress_measure_ = elastic_solid_.getRelevantStressMeasureName();
 }
 //=================================================================================================//
 Matd ElasticSolidParticles::getGreenLagrangeStrain(size_t particle_i)
 {
-		Matd F = F_[particle_i];
-		return 0.5 * (F.transpose() * F - Matd::Identity());
+    Matd F = F_[particle_i];
+    return 0.5 * (F.transpose() * F - Matd::Identity());
 }
 //=================================================================================================//
 Vecd ElasticSolidParticles::getPrincipalStrains(size_t particle_i)
 {
     Matd epsilon = getGreenLagrangeStrain(particle_i);
-		return getPrincipalValuesFromMatrix(epsilon);
+    return getPrincipalValuesFromMatrix(epsilon);
 }
 //=================================================================================================//
 Matd ElasticSolidParticles::getStressCauchy(size_t particle_i)
 {
-		Matd F = F_[particle_i];
-		Matd stress_PK2 = elastic_solid_.StressPK2(F, particle_i);
-		return (1.0 / F.determinant()) * F * stress_PK2 * F.transpose();
+    Matd F = F_[particle_i];
+    Matd stress_PK2 = elastic_solid_.StressPK2(F, particle_i);
+    return (1.0 / F.determinant()) * F * stress_PK2 * F.transpose();
 }
 //=================================================================================================//
 Matd ElasticSolidParticles::getStressPK2(size_t particle_i)
 {
-		return elastic_solid_.StressPK2(F_[particle_i], particle_i);
+    return elastic_solid_.StressPK2(F_[particle_i], particle_i);
 }
 //=================================================================================================//
 Vecd ElasticSolidParticles::getPrincipalStresses(size_t particle_i)
 {
-		Matd sigma;
-		if (stress_measure_ == "Cauchy")
-		{
-			sigma = getStressCauchy(particle_i); // Cauchy stress
-		}
-		else if (stress_measure_ == "PK2")
-		{
-			sigma = getStressPK2(particle_i); // Second Piola-Kirchhoff stress
-		}
-		else
-		{
-			throw std::runtime_error("get_Principal_stresses: wrong input");
-		}
+    Matd sigma;
+    if (stress_measure_ == "Cauchy")
+    {
+        sigma = getStressCauchy(particle_i); // Cauchy stress
+    }
+    else if (stress_measure_ == "PK2")
+    {
+        sigma = getStressPK2(particle_i); // Second Piola-Kirchhoff stress
+    }
+    else
+    {
+        throw std::runtime_error("get_Principal_stresses: wrong input");
+    }
 
-		return getPrincipalValuesFromMatrix(sigma);
+    return getPrincipalValuesFromMatrix(sigma);
 }
 //=================================================================================================//
 Real ElasticSolidParticles::getVonMisesStress(size_t particle_i)
 {
-		Matd sigma;
-		if (stress_measure_ == "Cauchy")
-		{
-			sigma = getStressCauchy(particle_i); // Cauchy stress
-		}
-		else if (stress_measure_ == "PK2")
-		{
-			sigma = getStressPK2(particle_i); // Second Piola-Kirchhoff stress
-		}
-		else
-		{
-			throw std::runtime_error("get_von_Mises_stress: wrong input");
-		}
+    Matd sigma;
+    if (stress_measure_ == "Cauchy")
+    {
+        sigma = getStressCauchy(particle_i); // Cauchy stress
+    }
+    else if (stress_measure_ == "PK2")
+    {
+        sigma = getStressPK2(particle_i); // Second Piola-Kirchhoff stress
+    }
+    else
+    {
+        throw std::runtime_error("get_von_Mises_stress: wrong input");
+    }
 
-		return getVonMisesStressFromMatrix(sigma);
+    return getVonMisesStressFromMatrix(sigma);
 }
 //=================================================================================================//
 StdLargeVec<Real> ElasticSolidParticles::getVonMisesStrainVector(std::string strain_measure)
 {
-		StdLargeVec<Real> strain_vector = {};
-		for (size_t index_i = 0; index_i < pos0_.size(); index_i++)
-		{
-			Real strain = 0.0;
-			if (strain_measure == "static")
-			{
-				strain = getVonMisesStrain(index_i);
-			}
-			else if (strain_measure == "dynamic")
-			{
-				strain = getVonMisesStrainDynamic(index_i, elastic_solid_.PoissonRatio());
-			}
-			else
-			{
-				throw std::runtime_error("getVonMisesStrainVector: wrong input");
-			}
+    StdLargeVec<Real> strain_vector = {};
+    for (size_t index_i = 0; index_i < pos0_.size(); index_i++)
+    {
+        Real strain = 0.0;
+        if (strain_measure == "static")
+        {
+            strain = getVonMisesStrain(index_i);
+        }
+        else if (strain_measure == "dynamic")
+        {
+            strain = getVonMisesStrainDynamic(index_i, elastic_solid_.PoissonRatio());
+        }
+        else
+        {
+            throw std::runtime_error("getVonMisesStrainVector: wrong input");
+        }
 
-			strain_vector.push_back(strain);
-		}
+        strain_vector.push_back(strain);
+    }
 
-		return strain_vector;
+    return strain_vector;
 }
 //=================================================================================================//
 Real ElasticSolidParticles::getVonMisesStrainMax(std::string strain_measure)
 {
-		Real strain_max = 0;
-		for (size_t index_i = 0; index_i < pos0_.size(); index_i++)
-		{
-			Real strain = 0.0;
-			if (strain_measure == "static")
-			{
-				strain = getVonMisesStrain(index_i);
-			}
-			else if (strain_measure == "dynamic")
-			{
-				strain = getVonMisesStrainDynamic(index_i, elastic_solid_.PoissonRatio());
-			}
-			else
-			{
-				throw std::runtime_error("getVonMisesStrainMax: wrong input");
-			}
-			if (strain_max < strain)
-				strain_max = strain;
-		}
-		return strain_max;
+    Real strain_max = 0;
+    for (size_t index_i = 0; index_i < pos0_.size(); index_i++)
+    {
+        Real strain = 0.0;
+        if (strain_measure == "static")
+        {
+            strain = getVonMisesStrain(index_i);
+        }
+        else if (strain_measure == "dynamic")
+        {
+            strain = getVonMisesStrainDynamic(index_i, elastic_solid_.PoissonRatio());
+        }
+        else
+        {
+            throw std::runtime_error("getVonMisesStrainMax: wrong input");
+        }
+        if (strain_max < strain)
+            strain_max = strain;
+    }
+    return strain_max;
 }
 //=================================================================================================//
 Real ElasticSolidParticles::getPrincipalStressMax()
 {
-		Real stress_max = 0.0;
-		for (size_t index_i = 0; index_i < pos0_.size(); index_i++)
-		{
-			/** take the max. component, which is the first one, this represents the max. tension. */
+    Real stress_max = 0.0;
+    for (size_t index_i = 0; index_i < pos0_.size(); index_i++)
+    {
+        /** take the max. component, which is the first one, this represents the max. tension. */
         Real stress = getPrincipalStresses(index_i)[0];
-			if (stress_max < stress)
-				stress_max = stress;
-		}
-		return stress_max;
+        if (stress_max < stress)
+            stress_max = stress;
+    }
+    return stress_max;
 };
 //=================================================================================================//
 StdLargeVec<Real> ElasticSolidParticles::getVonMisesStressVector()
 {
-		StdLargeVec<Real> stress_vector = {};
-		for (size_t index_i = 0; index_i < pos0_.size(); index_i++)
-		{
-			Real stress = getVonMisesStress(index_i);
-			stress_vector.push_back(stress);
-		}
-		return stress_vector;
+    StdLargeVec<Real> stress_vector = {};
+    for (size_t index_i = 0; index_i < pos0_.size(); index_i++)
+    {
+        Real stress = getVonMisesStress(index_i);
+        stress_vector.push_back(stress);
+    }
+    return stress_vector;
 }
 //=================================================================================================//
 Real ElasticSolidParticles::getVonMisesStressMax()
 {
-		Real stress_max = 0.0;
-		for (size_t index_i = 0; index_i < pos0_.size(); index_i++)
-		{
-			Real stress = getVonMisesStress(index_i);
-			if (stress_max < stress)
-				stress_max = stress;
-		}
-		return stress_max;
+    Real stress_max = 0.0;
+    for (size_t index_i = 0; index_i < pos0_.size(); index_i++)
+    {
+        Real stress = getVonMisesStress(index_i);
+        if (stress_max < stress)
+            stress_max = stress;
+    }
+    return stress_max;
 }
 //=================================================================================================//
 Vecd ElasticSolidParticles::displacement(size_t particle_i)
 {
-		return pos_[particle_i] - pos0_[particle_i];
+    return pos_[particle_i] - pos0_[particle_i];
 }
 //=================================================================================================//
 Vecd ElasticSolidParticles::normal(size_t particle_i)
 {
-		return n_[particle_i];
+    return n_[particle_i];
 }
 //=================================================================================================//
 StdLargeVec<Vecd> ElasticSolidParticles::getDisplacement()
 {
-		StdLargeVec<Vecd> displacement_vector = {};
-		for (size_t index_i = 0; index_i < pos0_.size(); index_i++)
-		{
-			displacement_vector.push_back(displacement(index_i));
-		}
-		return displacement_vector;
+    StdLargeVec<Vecd> displacement_vector = {};
+    for (size_t index_i = 0; index_i < pos0_.size(); index_i++)
+    {
+        displacement_vector.push_back(displacement(index_i));
+    }
+    return displacement_vector;
 }
 //=================================================================================================//
 Real ElasticSolidParticles::getMaxDisplacement()
 {
-		Real displ_max = 0.0;
-		for (size_t index_i = 0; index_i < pos0_.size(); index_i++)
-		{
-			Real displ = displacement(index_i).norm();
-			if (displ_max < displ)
-				displ_max = displ;
-		}
-		return displ_max;
+    Real displ_max = 0.0;
+    for (size_t index_i = 0; index_i < pos0_.size(); index_i++)
+    {
+        Real displ = displacement(index_i).norm();
+        if (displ_max < displ)
+            displ_max = displ;
+    }
+    return displ_max;
 };
 //=================================================================================================//
 StdLargeVec<Vecd> ElasticSolidParticles::getNormal()
 {
-		StdLargeVec<Vecd> normal_vector = {};
-		for (size_t index_i = 0; index_i < pos0_.size(); index_i++)
-		{
-			normal_vector.push_back(normal(index_i));
-		}
-		return normal_vector;
+    StdLargeVec<Vecd> normal_vector = {};
+    for (size_t index_i = 0; index_i < pos0_.size(); index_i++)
+    {
+        normal_vector.push_back(normal(index_i));
+    }
+    return normal_vector;
 }
 //=============================================================================================//
 ShellParticles::ShellParticles(SPHBody &sph_body, ElasticSolid *elastic_solid)
-		: ElasticSolidParticles(sph_body, elastic_solid), thickness_ref_(1.0)
+    : ElasticSolidParticles(sph_body, elastic_solid), thickness_ref_(1.0)
 {
-		//----------------------------------------------------------------------
-		//		modify kernel function for surface particles
-		//----------------------------------------------------------------------
-		sph_body.sph_adaptation_->getKernel()->reduceOnce();
-		//----------------------------------------------------------------------
-		//		register geometric data only
-		//----------------------------------------------------------------------
-		registerVariable(n_, "NormalDirection");
-		registerVariable(thickness_, "Thickness");
-		/**
-		 * add particle reload data
-		 */
+    //----------------------------------------------------------------------
+    //		modify kernel function for surface particles
+    //----------------------------------------------------------------------
+    sph_body.sph_adaptation_->getKernel()->reduceOnce();
+    //----------------------------------------------------------------------
+    //		register geometric data only
+    //----------------------------------------------------------------------
+    registerVariable(n_, "NormalDirection");
+    registerVariable(thickness_, "Thickness");
+    /**
+     * add particle reload data
+     */
     addVariableToList<Vecd>(variables_to_reload_, "NormalDirection");
     addVariableToList<Real>(variables_to_reload_, "Thickness");
 }
@@ -329,10 +336,10 @@ void ShellParticles::initializeOtherVariables()
      */
     for (size_t i = 0; i != real_particles_bound_; ++i)
     {
-                        transformation_matrix_[i] = getTransformationMatrix(n_[i]);
-                        numerical_damping_scaling_[i](Dimensions - 1, Dimensions - 1) =
-                            thickness_[i] < sph_body_.sph_adaptation_->ReferenceSmoothingLength() ? thickness_[i] : sph_body_.sph_adaptation_->ReferenceSmoothingLength();
+        transformation_matrix_[i] = getTransformationMatrix(n_[i]);
+        numerical_damping_scaling_[i](Dimensions - 1, Dimensions - 1) =
+            thickness_[i] < sph_body_.sph_adaptation_->ReferenceSmoothingLength() ? thickness_[i] : sph_body_.sph_adaptation_->ReferenceSmoothingLength();
     }
 }
 
-        }
+} // namespace SPH

--- a/src/shared/particles/solid_particles.h
+++ b/src/shared/particles/solid_particles.h
@@ -26,8 +26,8 @@
  * @author	Chi Zhang, Dong Wu and Xiangyu Hu
  */
 
-#ifndef SOLID_PARTICLES_H
-#define SOLID_PARTICLES_H
+#ifndef VIRTOSIM_SOLID_PARTICLES_H_D48B63F3_F82E_48D4_8F2B_C76F32C36090
+#define VIRTOSIM_SOLID_PARTICLES_H_D48B63F3_F82E_48D4_8F2B_C76F32C36090
 
 #include "base_particles.h"
 #include "base_particles.hpp"
@@ -50,13 +50,13 @@ class SolidParticles : public BaseParticles
 {
   public:
     SolidParticles(SPHBody &sph_body, Solid *solid);
-    virtual ~SolidParticles(){};
+    SolidParticles(SPHBody &sph_body, BaseMaterial *solid);
+    virtual ~SolidParticles() {};
 
     StdLargeVec<Vecd> pos0_; /**< initial position */
     StdLargeVec<Vecd> n_;    /**< normal direction */
     StdLargeVec<Vecd> n0_;   /**< initial normal direction */
     StdLargeVec<Matd> B_;    /**< configuration correction for linear reproducing */
-    Solid &solid_;
 
     /** Get wall average velocity when interacting with fluid. */
     virtual StdLargeVec<Vecd> *AverageVelocity() { return &vel_; };
@@ -66,6 +66,12 @@ class SolidParticles : public BaseParticles
     virtual void initializeOtherVariables() override;
     /** Return this pointer. */
     virtual SolidParticles *ThisObjectPtr() override { return this; };
+
+  private:
+    Solid *solid_data_ = nullptr;
+
+  public:
+    Solid &solid_;
 };
 
 /**
@@ -76,11 +82,12 @@ class ElasticSolidParticles : public SolidParticles
 {
   public:
     ElasticSolidParticles(SPHBody &sph_body, ElasticSolid *elastic_solid);
-    virtual ~ElasticSolidParticles(){};
+    ElasticSolidParticles(SPHBody &sph_body, BaseMaterial *elastic_solid);
+
+    virtual ~ElasticSolidParticles() {};
 
     StdLargeVec<Matd> F_;     /**<  deformation tensor */
     StdLargeVec<Matd> dF_dt_; /**<  deformation tensor change rate */
-    ElasticSolid &elastic_solid_;
     //----------------------------------------------------------------------
     //		for fluid-structure interaction (FSI)
     //----------------------------------------------------------------------
@@ -139,6 +146,12 @@ class ElasticSolidParticles : public SolidParticles
     virtual void initializeOtherVariables() override;
     /** Return this pointer. */
     virtual ElasticSolidParticles *ThisObjectPtr() override { return this; };
+
+  private:
+    ElasticSolid *elastic_solid_data_;
+
+  public:
+    ElasticSolid &elastic_solid_;
 };
 
 /**
@@ -149,7 +162,7 @@ class ShellParticles : public ElasticSolidParticles
 {
   public:
     ShellParticles(SPHBody &sph_body, ElasticSolid *elastic_solid);
-    virtual ~ShellParticles(){};
+    virtual ~ShellParticles() {};
 
     Real thickness_ref_;                      /**< Shell thickness. */
     StdLargeVec<Matd> transformation_matrix_; /**< initial transformation matrix from global to local coordinates */
@@ -196,7 +209,5 @@ class ShellParticles : public ElasticSolidParticles
     virtual ShellParticles *ThisObjectPtr() override { return this; };
 };
 
-
-
-}
-#endif // SOLID_PARTICLES_H
+} // namespace SPH
+#endif // VIRTOSIM_SOLID_PARTICLES_H_D48B63F3_F82E_48D4_8F2B_C76F32C36090


### PR DESCRIPTION
Ref: [Differential geometry and the geometrically non-linear Reissner-Mindlin shell model](http://dx.doi.org/10.18419/opus-14215)

The current method uses the Young's modulus E0_ as the initial derivative dS/de. This PR replaces it with $\lambda+2\mu=K+4/3G$, which is the analytical derivative of the linear elastic material.