### PR TITLE
Fluid dynamics with an additional contact relation

### DIFF
--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex.h
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex.h
@@ -28,8 +28,8 @@
  * @author	Chi Zhang and Xiangyu Hu
  */
 
-#ifndef FLUID_DYNAMICS_COMPLEX_H
-#define FLUID_DYNAMICS_COMPLEX_H
+#ifndef VIRTOSIM_FLUID_DYNAMICS_COMPLEX_H_EF1F0D15_AEAF_4151_AC74_DEF4ACD4136F
+#define VIRTOSIM_FLUID_DYNAMICS_COMPLEX_H_EF1F0D15_AEAF_4151_AC74_DEF4ACD4136F
 
 #include "fluid_dynamics_inner.h"
 #include "fluid_dynamics_inner.hpp"
@@ -50,17 +50,12 @@ typedef DataDelegateContact<BaseParticles, SolidParticles> FSIContactData;
  * @brief Base class adding interaction with wall to general relaxation process
  */
 template <class BaseIntegrationType>
-class InteractionWithWall : public BaseIntegrationType, public FluidWallData
+class InteractionWithWall : public BaseInteractionComplex<BaseIntegrationType, FluidWallData>
 {
   public:
-    template <class BaseBodyRelationType, typename... Args>
-    InteractionWithWall(BaseContactRelation &wall_contact_relation,
-                        BaseBodyRelationType &base_body_relation, Args &&...args);
     template <typename... Args>
-    InteractionWithWall(ComplexRelation &fluid_wall_relation, Args &&...args)
-        : InteractionWithWall(fluid_wall_relation.getContactRelation(),
-                              fluid_wall_relation.getInnerRelation(), std::forward<Args>(args)...) {}
-    virtual ~InteractionWithWall(){};
+    InteractionWithWall(Args &&...args);
+    virtual ~InteractionWithWall() {};
 
   protected:
     StdVec<Real> wall_inv_rho0_;
@@ -79,7 +74,7 @@ class BaseDensitySummationComplex
   public:
     template <typename... Args>
     explicit BaseDensitySummationComplex(Args &&...args);
-    virtual ~BaseDensitySummationComplex(){};
+    virtual ~BaseDensitySummationComplex() {};
 
   protected:
     StdVec<Real> contact_inv_rho0_;
@@ -99,7 +94,7 @@ class DensitySummationComplex
     template <typename... Args>
     explicit DensitySummationComplex(Args &&...args)
         : BaseDensitySummationComplex<DensitySummationInner>(std::forward<Args>(args)...){};
-    virtual ~DensitySummationComplex(){};
+    virtual ~DensitySummationComplex() {};
 
     inline void interaction(size_t index_i, Real dt = 0.0);
 };
@@ -115,7 +110,7 @@ class DensitySummationComplexAdaptive
     template <typename... Args>
     explicit DensitySummationComplexAdaptive(Args &&...args)
         : BaseDensitySummationComplex<DensitySummationInnerAdaptive>(std::forward<Args>(args)...){};
-    virtual ~DensitySummationComplexAdaptive(){};
+    virtual ~DensitySummationComplexAdaptive() {};
 
     inline void interaction(size_t index_i, Real dt = 0.0);
 };
@@ -131,7 +126,7 @@ class BaseViscousAccelerationWithWall : public InteractionWithWall<ViscousAccele
     template <typename... Args>
     BaseViscousAccelerationWithWall(Args &&...args)
         : InteractionWithWall<ViscousAccelerationInnerType>(std::forward<Args>(args)...){};
-    virtual ~BaseViscousAccelerationWithWall(){};
+    virtual ~BaseViscousAccelerationWithWall() {};
 
     inline void interaction(size_t index_i, Real dt = 0.0);
 };
@@ -150,7 +145,7 @@ class TransportVelocityCorrectionComplex
     TransportVelocityCorrectionComplex(Args &&...args)
         : BaseInteractionComplex<TransportVelocityCorrectionInner, FluidContactData>(
               std::forward<Args>(args)...){};
-    virtual ~TransportVelocityCorrectionComplex(){};
+    virtual ~TransportVelocityCorrectionComplex() {};
 
     inline void interaction(size_t index_i, Real dt = 0.0);
 };
@@ -167,7 +162,7 @@ class TransportVelocityCorrectionComplexAdaptive
     TransportVelocityCorrectionComplexAdaptive(Args &&...args)
         : BaseInteractionComplex<TransportVelocityCorrectionInnerAdaptive, FluidContactData>(
               std::forward<Args>(args)...){};
-    virtual ~TransportVelocityCorrectionComplexAdaptive(){};
+    virtual ~TransportVelocityCorrectionComplexAdaptive() {};
 
     inline void interaction(size_t index_i, Real dt = 0.0);
 };
@@ -183,7 +178,7 @@ class BaseIntegration1stHalfWithWall : public InteractionWithWall<BaseIntegratio
     template <typename... Args>
     BaseIntegration1stHalfWithWall(Args &&...args)
         : InteractionWithWall<BaseIntegration1stHalfType>(std::forward<Args>(args)...){};
-    virtual ~BaseIntegration1stHalfWithWall(){};
+    virtual ~BaseIntegration1stHalfWithWall() {};
 
     inline void interaction(size_t index_i, Real dt = 0.0);
 
@@ -220,7 +215,7 @@ class BaseExtendIntegration1stHalfWithWall : public BaseIntegration1stHalfWithWa
         : BaseExtendIntegration1stHalfWithWall(fluid_wall_relation.getContactRelation(),
                                                fluid_wall_relation.getInnerRelation(),
                                                std::forward<Args>(args)..., penalty_strength){};
-    virtual ~BaseExtendIntegration1stHalfWithWall(){};
+    virtual ~BaseExtendIntegration1stHalfWithWall() {};
     void initialization(size_t index_i, Real dt = 0.0);
 
     inline void interaction(size_t index_i, Real dt = 0.0);
@@ -246,7 +241,7 @@ class BaseIntegration2ndHalfWithWall : public InteractionWithWall<BaseIntegratio
     template <typename... Args>
     BaseIntegration2ndHalfWithWall(Args &&...args)
         : InteractionWithWall<BaseIntegration2ndHalfType>(std::forward<Args>(args)...){};
-    virtual ~BaseIntegration2ndHalfWithWall(){};
+    virtual ~BaseIntegration2ndHalfWithWall() {};
 
     inline void interaction(size_t index_i, Real dt = 0.0);
 };
@@ -262,9 +257,9 @@ class Oldroyd_BIntegration1stHalfWithWall : public BaseIntegration1stHalfWithWal
 {
   public:
     explicit Oldroyd_BIntegration1stHalfWithWall(ComplexRelation &fluid_wall_relation)
-        : BaseIntegration1stHalfWithWall<Oldroyd_BIntegration1stHalf>(fluid_wall_relation){};
+        : BaseIntegration1stHalfWithWall<Oldroyd_BIntegration1stHalf>(fluid_wall_relation) {};
 
-    virtual ~Oldroyd_BIntegration1stHalfWithWall(){};
+    virtual ~Oldroyd_BIntegration1stHalfWithWall() {};
 
     inline void interaction(size_t index_i, Real dt = 0.0);
 };
@@ -277,12 +272,12 @@ class Oldroyd_BIntegration2ndHalfWithWall : public BaseIntegration2ndHalfWithWal
 {
   public:
     explicit Oldroyd_BIntegration2ndHalfWithWall(ComplexRelation &fluid_wall_relation)
-        : BaseIntegration2ndHalfWithWall<Oldroyd_BIntegration2ndHalf>(fluid_wall_relation){};
+        : BaseIntegration2ndHalfWithWall<Oldroyd_BIntegration2ndHalf>(fluid_wall_relation) {};
 
-    virtual ~Oldroyd_BIntegration2ndHalfWithWall(){};
+    virtual ~Oldroyd_BIntegration2ndHalfWithWall() {};
 
     inline void interaction(size_t index_i, Real dt = 0.0);
 };
 } // namespace fluid_dynamics
 } // namespace SPH
-#endif // FLUID_DYNAMICS_COMPLEX_H
+#endif // VIRTOSIM_FLUID_DYNAMICS_COMPLEX_H_EF1F0D15_AEAF_4151_AC74_DEF4ACD4136F

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex.hpp
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex.hpp
@@ -131,20 +131,11 @@ void Oldroyd_BIntegration2ndHalfWithWall::
 }
 //=================================================================================================//
 template <class BaseIntegrationType>
-template <class BaseBodyRelationType, typename... Args>
+template <typename... Args>
 InteractionWithWall<BaseIntegrationType>::
-    InteractionWithWall(BaseContactRelation &wall_contact_relation,
-                        BaseBodyRelationType &base_body_relation, Args &&...args)
-    : BaseIntegrationType(base_body_relation, std::forward<Args>(args)...),
-      FluidWallData(wall_contact_relation)
+    InteractionWithWall(Args &&...args)
+    : BaseInteractionComplex<BaseIntegrationType, FluidWallData>(std::forward<Args>(args)...)
 {
-    if (&base_body_relation.getSPHBody() != &wall_contact_relation.getSPHBody())
-    {
-        std::cout << "\n Error: the two body_relations do not have the same source body!" << std::endl;
-        std::cout << __FILE__ << ':' << __LINE__ << std::endl;
-        exit(1);
-    }
-
     for (size_t k = 0; k != FluidWallData::contact_particles_.size(); ++k)
     {
         Real rho0_k = FluidWallData::contact_bodies_[k]->base_material_->ReferenceDensity();

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_surface_complex.cpp
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_surface_complex.cpp
@@ -6,24 +6,6 @@ namespace SPH
 namespace fluid_dynamics
 {
 //=================================================================================================//
-FreeSurfaceIndicationComplex::
-    FreeSurfaceIndicationComplex(BaseInnerRelation &inner_relation,
-                                 BaseContactRelation &contact_relation, Real threshold)
-    : FreeSurfaceIndicationInner(inner_relation, threshold), FluidContactData(contact_relation)
-{
-    for (size_t k = 0; k != contact_particles_.size(); ++k)
-    {
-        Real rho0_k = contact_bodies_[k]->base_material_->ReferenceDensity();
-        contact_inv_rho0_.push_back(1.0 / rho0_k);
-        contact_mass_.push_back(&(contact_particles_[k]->mass_));
-    }
-}
-//=================================================================================================//
-FreeSurfaceIndicationComplex::
-    FreeSurfaceIndicationComplex(ComplexRelation &complex_relation, Real threshold)
-    : FreeSurfaceIndicationComplex(complex_relation.getInnerRelation(),
-                                   complex_relation.getContactRelation(), threshold) {}
-//=================================================================================================//
 ColorFunctionGradientComplex::ColorFunctionGradientComplex(BaseInnerRelation &inner_relation,
                                                            BaseContactRelation &contact_relation)
     : ColorFunctionGradientInner(inner_relation), FluidContactData(contact_relation)

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_surface_complex.h
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_surface_complex.h
@@ -28,8 +28,8 @@
  * @author	Chi Zhang and Xiangyu Hu
  */
 
-#ifndef FLUID_SURFACE_COMPLEX_H
-#define FLUID_SURFACE_COMPLEX_H
+#ifndef VIRTOSIM_FLUID_SURFACE_COMPLEX_H_A72FE1EB_7943_4903_BB70_3000ABECD2AB
+#define VIRTOSIM_FLUID_SURFACE_COMPLEX_H_A72FE1EB_7943_4903_BB70_3000ABECD2AB
 
 #include "fluid_dynamics_complex.hpp"
 #include "fluid_surface_inner.hpp"
@@ -42,13 +42,21 @@ namespace fluid_dynamics
  * @class FreeSurfaceIndicationComplex
  * @brief indicate the particles near the free fluid surface.
  */
-class FreeSurfaceIndicationComplex : public FreeSurfaceIndicationInner, public FluidContactData
+class FreeSurfaceIndicationComplex : public BaseInteractionComplex<FreeSurfaceIndicationInner, FluidContactData>
 {
   public:
-    FreeSurfaceIndicationComplex(BaseInnerRelation &inner_relation,
-                                 BaseContactRelation &contact_relation, Real threshold = 0.75);
-    explicit FreeSurfaceIndicationComplex(ComplexRelation &complex_relation, Real threshold = 0.75);
-    virtual ~FreeSurfaceIndicationComplex(){};
+    template <typename... Args>
+    explicit FreeSurfaceIndicationComplex(Args &&...args)
+        : BaseInteractionComplex<FreeSurfaceIndicationInner, FluidContactData>(std::forward<Args>(args)...)
+    {
+        for (size_t k = 0; k != contact_particles_.size(); ++k)
+        {
+            Real rho0_k = contact_bodies_[k]->base_material_->ReferenceDensity();
+            contact_inv_rho0_.push_back(1.0 / rho0_k);
+            contact_mass_.push_back(&(contact_particles_[k]->mass_));
+        }
+    }
+    virtual ~FreeSurfaceIndicationComplex() {};
 
     inline void interaction(size_t index_i, Real dt = 0.0)
     {
@@ -89,7 +97,7 @@ class ColorFunctionGradientComplex : public ColorFunctionGradientInner, public F
   public:
     ColorFunctionGradientComplex(BaseInnerRelation &inner_relation, BaseContactRelation &contact_relation);
     ColorFunctionGradientComplex(ComplexRelation &complex_relation);
-    virtual ~ColorFunctionGradientComplex(){};
+    virtual ~ColorFunctionGradientComplex() {};
 
     inline void interaction(size_t index_i, Real dt = 0.0)
     {
@@ -123,7 +131,7 @@ class SurfaceNormWithWall : public LocalDynamics, public FSIContactData
 {
   public:
     SurfaceNormWithWall(BaseContactRelation &contact_relation, Real contact_angle);
-    virtual ~SurfaceNormWithWall(){};
+    virtual ~SurfaceNormWithWall() {};
 
     inline void interaction(size_t index_i, Real dt = 0.0)
     {
@@ -177,4 +185,4 @@ class SurfaceNormWithWall : public LocalDynamics, public FSIContactData
 };
 } // namespace fluid_dynamics
 } // namespace SPH
-#endif // FLUID_SURFACE_COMPLEX_H
+#endif // VIRTOSIM_FLUID_SURFACE_COMPLEX_H_A72FE1EB_7943_4903_BB70_3000ABECD2AB


### PR DESCRIPTION
In FSI simulation, we usually add all the solid bodies in one contact relation. However, when the fluid has contact with both solid bodies and shell bodies, we need to use different types of contact relations; hence, there will be one additional contact relation used for fluid-shell interaction.
The class `BaseInteractionComplex` in SPHinXsys allows fluid dynamics to have one more contact relation. This PR modifies those fluid dynamics classes that can only take one complex relation to ensure that all the dynamic classes can take two contact relations as parameters.
The newer SPHinXsys uses templates to allow the fluid dynamics classes to have any number of contact relations as arguments. We might need to further improve the complex dynamics class as well, in case there are more than 2 types of contact relations.