### PR TITLE
Fix plastic first half integration

### DIFF
--- a/src/shared/particle_dynamics/solid_dynamics/inelastic_dynamics.cpp
+++ b/src/shared/particle_dynamics/solid_dynamics/inelastic_dynamics.cpp
@@ -7,10 +7,9 @@ namespace solid_dynamics
 {
 //=================================================================================================//
 PlasticIntegration1stHalf::
-    PlasticIntegration1stHalf(BaseInnerRelation &inner_relation) : Integration1stHalf(inner_relation),
-                                                                   plastic_solid_(DynamicCast<PlasticSolid>(this, elastic_solid_))
+    PlasticIntegration1stHalf(BaseInnerRelation &inner_relation, Real numerical_dissipation_factor) : Integration1stHalf(inner_relation, numerical_dissipation_factor),
+                                                                                                      plastic_solid_(DynamicCast<PlasticSolid>(this, elastic_solid_))
 {
-    numerical_dissipation_factor_ = 0.5;
 }
 //=================================================================================================//
 void PlasticIntegration1stHalf::initialization(size_t index_i, Real dt)

--- a/src/shared/particle_dynamics/solid_dynamics/inelastic_dynamics.h
+++ b/src/shared/particle_dynamics/solid_dynamics/inelastic_dynamics.h
@@ -45,8 +45,8 @@ class PlasticIntegration1stHalf
     : public Integration1stHalf
 {
   public:
-    PlasticIntegration1stHalf(BaseInnerRelation &inner_relation);
-    virtual ~PlasticIntegration1stHalf(){};
+    PlasticIntegration1stHalf(BaseInnerRelation &inner_relation, Real numerical_dissipation_factor = 0.5);
+    virtual ~PlasticIntegration1stHalf() {};
     void initialization(size_t index_i, Real dt = 0.0);
 
   protected:


### PR DESCRIPTION
`PlasticIntegration1stHalf` was not corrected in the previous PR #140 . Fix this problem.